### PR TITLE
Fix Drafts mode ghost for __MCP_CommandListener

### DIFF
--- a/studio-plugin/src/modules/NavCommandListener.ts
+++ b/studio-plugin/src/modules/NavCommandListener.ts
@@ -1,0 +1,101 @@
+import { RunService } from "@rbxts/services";
+
+const ServerScriptService = game.GetService("ServerScriptService");
+
+export const NAV_SIGNAL = "__MCP_NAV__";
+export const NAV_RESULT = "__MCP_NAV_RESULT__";
+const COMMAND_LISTENER_NAME = "__MCP_CommandListener";
+
+let installedListener: Script | undefined;
+
+function buildCommandListenerSource(): string {
+	return `local LogService = game:GetService("LogService")
+local PathfindingService = game:GetService("PathfindingService")
+local Players = game:GetService("Players")
+local HttpService = game:GetService("HttpService")
+local NAV_SIG = "${NAV_SIGNAL}"
+local NAV_RES = "${NAV_RESULT}"
+LogService.MessageOut:Connect(function(msg)
+	if string.sub(msg, 1, #NAV_SIG + 1) == NAV_SIG .. ":" then
+		local json = string.sub(msg, #NAV_SIG + 2)
+		task.spawn(function()
+			local ok, d = pcall(function() return HttpService:JSONDecode(json) end)
+			if not ok or not d then
+				print(NAV_RES .. ':{"success":false,"error":"parse_error"}')
+				return
+			end
+			local ps = Players:GetPlayers()
+			if #ps == 0 then
+				print(NAV_RES .. ':{"success":false,"error":"no_players"}')
+				return
+			end
+			local char = ps[1].Character or ps[1].CharacterAdded:Wait()
+			local hum = char:FindFirstChildOfClass("Humanoid")
+			local root = char:FindFirstChild("HumanoidRootPart")
+			if not hum or not root then
+				print(NAV_RES .. ':{"success":false,"error":"no_humanoid"}')
+				return
+			end
+			local target
+			if d.instancePath then
+				local parts = string.split(d.instancePath, ".")
+				local cur = game
+				for i = 2, #parts do
+					cur = cur:FindFirstChild(parts[i])
+					if not cur then
+						print(NAV_RES .. ':{"success":false,"error":"instance_not_found"}')
+						return
+					end
+				end
+				if cur:IsA("BasePart") then target = cur.Position
+				elseif cur:IsA("Model") and cur.PrimaryPart then target = cur.PrimaryPart.Position
+				else target = cur:GetPivot().Position end
+			else
+				target = Vector3.new(d.x or 0, d.y or 0, d.z or 0)
+			end
+			local path = PathfindingService:CreatePath({AgentRadius=2,AgentHeight=5,AgentCanJump=true})
+			local pok = pcall(function() path:ComputeAsync(root.Position, target) end)
+			local method = "direct"
+			if pok and path.Status == Enum.PathStatus.Success then
+				method = "pathfinding"
+				for _, wp in ipairs(path:GetWaypoints()) do
+					hum:MoveTo(wp.Position)
+					if wp.Action == Enum.PathWaypointAction.Jump then hum.Jump = true end
+					hum.MoveToFinished:Wait()
+				end
+			else
+				hum:MoveTo(target)
+				hum.MoveToFinished:Wait()
+			end
+			local fp = root.Position
+			print(NAV_RES .. ':{"success":true,"method":"' .. method .. '","position":[' .. fp.X .. ',' .. fp.Y .. ',' .. fp.Z .. ']}')
+		end)
+	end
+end)`;
+}
+
+// Install only in the play-server DataModel. Creating this script in edit mode
+// registers a Drafts-mode row even after Destroy(); the play DM is torn down
+// with the session so nothing lingers in the user's draft list.
+export function ensureNavCommandListener(): boolean {
+	if (!RunService.IsRunning() || !RunService.IsServer()) {
+		return false;
+	}
+
+	if (installedListener && installedListener.Parent) {
+		return true;
+	}
+
+	const existing = ServerScriptService.FindFirstChild(COMMAND_LISTENER_NAME);
+	if (existing && existing.IsA("Script")) {
+		installedListener = existing;
+		return true;
+	}
+
+	const listener = new Instance("Script");
+	listener.Name = COMMAND_LISTENER_NAME;
+	listener.Parent = ServerScriptService;
+	(listener as unknown as { Source: string }).Source = buildCommandListenerSource();
+	installedListener = listener;
+	return true;
+}

--- a/studio-plugin/src/modules/handlers/TestHandlers.ts
+++ b/studio-plugin/src/modules/handlers/TestHandlers.ts
@@ -1,4 +1,5 @@
 import { HttpService, LogService, Players, RunService } from "@rbxts/services";
+import { NAV_RESULT, NAV_SIGNAL } from "../NavCommandListener";
 import StopPlayMonitor from "../StopPlayMonitor";
 
 interface StudioTestServiceMultiplayer extends StudioTestService {
@@ -10,19 +11,14 @@ interface StudioTestServiceMultiplayer extends StudioTestService {
 }
 
 const StudioTestService = game.GetService("StudioTestService") as StudioTestServiceMultiplayer;
-const ServerScriptService = game.GetService("ServerScriptService");
-const ScriptEditorService = game.GetService("ScriptEditorService");
 
-// NAV_SIGNAL flows from the edit DM to the play-server DM via the injected
-// __MCP_CommandListener Script + LogService.MessageOut. Stop signaling moved
-// off this path entirely (see StopPlayMonitor) because cross-DM MessageOut
-// reflection from edit -> play-server does not work in practice.
-const NAV_SIGNAL = "__MCP_NAV__";
-const NAV_RESULT = "__MCP_NAV_RESULT__";
+// NAV_SIGNAL flows from the edit DM to the play-server DM via a runtime-only
+// __MCP_CommandListener Script installed by NavCommandListener on the server peer.
+// Stop signaling moved off this path entirely (see StopPlayMonitor) because cross-DM
+// MessageOut reflection from edit -> play-server does not work in practice.
 
 let testRunning = false;
 let navLogConnection: RBXScriptConnection | undefined;
-let stopListenerScript: Script | undefined;
 let navResultCallback: ((json: string) => void) | undefined;
 
 type MultiplayerPhase = "idle" | "starting" | "running" | "completed" | "failed";
@@ -78,95 +74,6 @@ function normalizeNumPlayers(value: unknown): number | undefined {
 	return n;
 }
 
-function buildCommandListenerSource(): string {
-	return `local LogService = game:GetService("LogService")
-local PathfindingService = game:GetService("PathfindingService")
-local Players = game:GetService("Players")
-local HttpService = game:GetService("HttpService")
-local NAV_SIG = "${NAV_SIGNAL}"
-local NAV_RES = "${NAV_RESULT}"
-LogService.MessageOut:Connect(function(msg)
-	if string.sub(msg, 1, #NAV_SIG + 1) == NAV_SIG .. ":" then
-		local json = string.sub(msg, #NAV_SIG + 2)
-		task.spawn(function()
-			local ok, d = pcall(function() return HttpService:JSONDecode(json) end)
-			if not ok or not d then
-				print(NAV_RES .. ':{"success":false,"error":"parse_error"}')
-				return
-			end
-			local ps = Players:GetPlayers()
-			if #ps == 0 then
-				print(NAV_RES .. ':{"success":false,"error":"no_players"}')
-				return
-			end
-			local char = ps[1].Character or ps[1].CharacterAdded:Wait()
-			local hum = char:FindFirstChildOfClass("Humanoid")
-			local root = char:FindFirstChild("HumanoidRootPart")
-			if not hum or not root then
-				print(NAV_RES .. ':{"success":false,"error":"no_humanoid"}')
-				return
-			end
-			local target
-			if d.instancePath then
-				local parts = string.split(d.instancePath, ".")
-				local cur = game
-				for i = 2, #parts do
-					cur = cur:FindFirstChild(parts[i])
-					if not cur then
-						print(NAV_RES .. ':{"success":false,"error":"instance_not_found"}')
-						return
-					end
-				end
-				if cur:IsA("BasePart") then target = cur.Position
-				elseif cur:IsA("Model") and cur.PrimaryPart then target = cur.PrimaryPart.Position
-				else target = cur:GetPivot().Position end
-			else
-				target = Vector3.new(d.x or 0, d.y or 0, d.z or 0)
-			end
-			local path = PathfindingService:CreatePath({AgentRadius=2,AgentHeight=5,AgentCanJump=true})
-			local pok = pcall(function() path:ComputeAsync(root.Position, target) end)
-			local method = "direct"
-			if pok and path.Status == Enum.PathStatus.Success then
-				method = "pathfinding"
-				for _, wp in ipairs(path:GetWaypoints()) do
-					hum:MoveTo(wp.Position)
-					if wp.Action == Enum.PathWaypointAction.Jump then hum.Jump = true end
-					hum.MoveToFinished:Wait()
-				end
-			else
-				hum:MoveTo(target)
-				hum.MoveToFinished:Wait()
-			end
-			local fp = root.Position
-			print(NAV_RES .. ':{"success":true,"method":"' .. method .. '","position":[' .. fp.X .. ',' .. fp.Y .. ',' .. fp.Z .. ']}')
-		end)
-	end
-end)`;
-}
-
-function injectStopListener() {
-	const listener = new Instance("Script");
-	listener.Name = "__MCP_CommandListener";
-	listener.Parent = ServerScriptService;
-
-	const source = buildCommandListenerSource();
-	const [seOk] = pcall(() => {
-		ScriptEditorService.UpdateSourceAsync(listener, () => source);
-	});
-	if (!seOk) {
-		(listener as unknown as { Source: string }).Source = source;
-	}
-
-	stopListenerScript = listener;
-}
-
-function cleanupStopListener() {
-	if (stopListenerScript) {
-		pcall(() => stopListenerScript!.Destroy());
-		stopListenerScript = undefined;
-	}
-}
-
 function disconnectNavLogListener() {
 	if (navLogConnection) {
 		navLogConnection.Disconnect();
@@ -193,7 +100,6 @@ function startPlaytest(requestData: Record<string, unknown>) {
 	if (testRunning && !RunService.IsRunning()) {
 		testRunning = false;
 		disconnectNavLogListener();
-		cleanupStopListener();
 		// Runtime eval bridges are created by the play server/client plugin
 		// peers and disappear with the play DataModels.
 	}
@@ -204,7 +110,6 @@ function startPlaytest(requestData: Record<string, unknown>) {
 
 	testRunning = true;
 
-	cleanupStopListener();
 	disconnectNavLogListener();
 
 	navLogConnection = LogService.MessageOut.Connect((message) => {
@@ -214,11 +119,6 @@ function startPlaytest(requestData: Record<string, unknown>) {
 			}
 		}
 	});
-
-	const [injected, injErr] = pcall(() => injectStopListener());
-	if (!injected) {
-		warn(`[robloxstudio-mcp] Failed to inject stop listener: ${injErr}`);
-	}
 
 	task.spawn(() => {
 		const [ok, result] = pcall(() => {
@@ -234,8 +134,6 @@ function startPlaytest(requestData: Record<string, unknown>) {
 
 		disconnectNavLogListener();
 		testRunning = false;
-
-		cleanupStopListener();
 	});
 
 	const response: Record<string, unknown> = {

--- a/studio-plugin/src/server/index.server.ts
+++ b/studio-plugin/src/server/index.server.ts
@@ -1,3 +1,4 @@
+import { RunService } from "@rbxts/services";
 import State from "../modules/State";
 import UI from "../modules/UI";
 import Communication from "../modules/Communication";
@@ -6,6 +7,7 @@ import ServerUrlSettings from "../modules/ServerUrlSettings";
 import { cleanupLegacyEditBridges, ensureRuntimeBridgeInstalled } from "../modules/EvalBridges";
 import RuntimeLogBuffer from "../modules/RuntimeLogBuffer";
 import StopPlayMonitor from "../modules/StopPlayMonitor";
+import { ensureNavCommandListener } from "../modules/NavCommandListener";
 import BreakpointHandlers from "../modules/handlers/BreakpointHandlers";
 import * as RenderMonitor from "../modules/RenderMonitor";
 
@@ -72,6 +74,10 @@ UI.updateUIState();
 Communication.checkForUpdates();
 task.delay(TOOLBAR_REGISTRATION_DELAY_SECONDS, registerToolbarButton);
 
+if (RunService.IsRunning() && RunService.IsServer()) {
+	ensureNavCommandListener();
+}
+
 // Auto-activate per peer. The boshyxd plugin only registers with MCP when the
 // user clicks Connect in its UI, but that UI is invisible in play DMs - so
 // play peers' plugin instances load without ever registering. Run after a
@@ -110,6 +116,7 @@ task.delay(2, () => {
 		});
 	}
 	if (role === "server") {
+		ensureNavCommandListener();
 		ClientBroker.setupServerBroker();
 		// The play-server DM is the only one where StudioTestService:EndTest is
 		// legal, so the stop-play monitor lives here. It consumes tokenized


### PR DESCRIPTION
## Summary

Fixes #8.

When Drafts mode is on, starting a playtest could leave `__MCP_CommandListener` in the Drafts list even after the playtest ended. This moves that script setup to the play-server side so edit mode does not create it.

## Test plan

- [x] Turn on Drafts mode
- [x] Run start_playtest, then stop_playtest
- [x] Confirm no new `__MCP_CommandListener` shows up in Drafts