### PR TITLE
Fix get_script_source large-file flooding, grep_scripts | alternation, and multiplayer_playtest false start/end status

### DIFF
--- a/packages/core/src/__tests__/http-server.test.ts
+++ b/packages/core/src/__tests__/http-server.test.ts
@@ -1,5 +1,5 @@
 import request from 'supertest';
-import { createHttpServer } from '../http-server.js';
+import { TOOL_HANDLERS, createHttpServer } from '../http-server.js';
 import { RobloxStudioTools } from '../tools/index.js';
 import { BridgeService } from '../bridge-service.js';
 import { Application } from 'express';
@@ -38,6 +38,145 @@ describe('HTTP Server', () => {
         pluginConnected: false,
         mcpServerActive: false,
       });
+    });
+  });
+
+  describe('Tool Handlers', () => {
+    test('get_script_source only accepts line_range for range selection', async () => {
+      const getScriptSource = jest.fn(async () => ({ content: [] }));
+      const fakeTools = { getScriptSource } as unknown as RobloxStudioTools;
+
+      await TOOL_HANDLERS.get_script_source(fakeTools, {
+        instancePath: 'game.ServerScriptService.Main',
+        line_range: '10-12',
+        instance_id: 'place:test',
+      });
+      expect(getScriptSource).toHaveBeenLastCalledWith('game.ServerScriptService.Main', 10, 12, 'place:test');
+
+      await TOOL_HANDLERS.get_script_source(fakeTools, {
+        instancePath: 'game.ServerScriptService.Main',
+        startLine: 20,
+        endLine: 25,
+        lineRange: '30-35',
+        instance_id: 'place:test',
+      });
+      expect(getScriptSource).toHaveBeenLastCalledWith('game.ServerScriptService.Main', undefined, undefined, 'place:test');
+    });
+
+    test('script line tools parse line_range through the shared handler helpers', async () => {
+      const editScriptLines = jest.fn(async () => ({ content: [] }));
+      const deleteScriptLines = jest.fn(async () => ({ content: [] }));
+      const fakeTools = { editScriptLines, deleteScriptLines } as unknown as RobloxStudioTools;
+
+      await TOOL_HANDLERS.edit_script_lines(fakeTools, {
+        instancePath: 'game.ServerScriptService.Main',
+        old_string: 'old',
+        new_string: 'new',
+        line_range: '42',
+        instance_id: 'place:test',
+      });
+      expect(editScriptLines).toHaveBeenLastCalledWith('game.ServerScriptService.Main', 'old', 'new', 42, 'place:test');
+
+      await TOOL_HANDLERS.delete_script_lines(fakeTools, {
+        instancePath: 'game.ServerScriptService.Main',
+        line_range: '10-12',
+        instance_id: 'place:test',
+      });
+      expect(deleteScriptLines).toHaveBeenLastCalledWith('game.ServerScriptService.Main', 10, 12, 'place:test');
+
+      await TOOL_HANDLERS.edit_script_lines(fakeTools, {
+        instancePath: 'game.ServerScriptService.Main',
+        old_string: 'old',
+        new_string: 'new',
+        startLine: 99,
+        instance_id: 'place:test',
+      });
+      expect(editScriptLines).toHaveBeenLastCalledWith('game.ServerScriptService.Main', 'old', 'new', undefined, 'place:test');
+    });
+
+    test('script line tools reject unsupported line_range shapes', async () => {
+      const editScriptLines = jest.fn(async () => ({ content: [] }));
+      const deleteScriptLines = jest.fn(async () => ({ content: [] }));
+      const fakeTools = { editScriptLines, deleteScriptLines } as unknown as RobloxStudioTools;
+
+      await expect(Promise.resolve().then(() => TOOL_HANDLERS.edit_script_lines(fakeTools, {
+        instancePath: 'game.ServerScriptService.Main',
+        old_string: 'old',
+        new_string: 'new',
+        line_range: '10-12',
+      }))).rejects.toThrow(/single line/);
+      expect(editScriptLines).not.toHaveBeenCalled();
+
+      await expect(Promise.resolve().then(() => TOOL_HANDLERS.delete_script_lines(fakeTools, {
+        instancePath: 'game.ServerScriptService.Main',
+        line_range: '10-',
+      }))).rejects.toThrow(/requires line_range/);
+      expect(deleteScriptLines).not.toHaveBeenCalled();
+
+      await expect(Promise.resolve().then(() => TOOL_HANDLERS.delete_script_lines(fakeTools, {
+        instancePath: 'game.ServerScriptService.Main',
+        line_range: '0',
+      }))).rejects.toThrow(/line_range must/);
+      expect(deleteScriptLines).not.toHaveBeenCalled();
+
+      await expect(Promise.resolve().then(() => TOOL_HANDLERS.delete_script_lines(fakeTools, {
+        instancePath: 'game.ServerScriptService.Main',
+        line_range: '12-10',
+      }))).rejects.toThrow(/line_range must/);
+      expect(deleteScriptLines).not.toHaveBeenCalled();
+
+      await expect(Promise.resolve().then(() => TOOL_HANDLERS.delete_script_lines(fakeTools, {
+        instancePath: 'game.ServerScriptService.Main',
+        startLine: 10,
+        endLine: 12,
+      }))).rejects.toThrow(/requires line_range/);
+      expect(deleteScriptLines).not.toHaveBeenCalled();
+    });
+
+    test('multiplayer handlers forward force for explicit hazardous start', async () => {
+      const multiplayerPlaytest = jest.fn(async () => ({ content: [] }));
+      const multiplayerTestStart = jest.fn(async () => ({ content: [] }));
+      const fakeTools = { multiplayerPlaytest, multiplayerTestStart } as unknown as RobloxStudioTools;
+
+      await TOOL_HANDLERS.multiplayer_playtest(fakeTools, {
+        action: 'start',
+        numPlayers: 2,
+        timeout: 5,
+        instance_id: 'place:test',
+        force: true,
+      });
+      expect(multiplayerPlaytest).toHaveBeenLastCalledWith('start', 2, undefined, undefined, undefined, 5, 'place:test', true);
+
+      await TOOL_HANDLERS.multiplayer_test_start(fakeTools, {
+        numPlayers: 2,
+        timeout: 5,
+        instance_id: 'place:test',
+        force: true,
+      });
+      expect(multiplayerTestStart).toHaveBeenLastCalledWith(2, undefined, 5, 'place:test', true);
+    });
+
+    test('grep_scripts uses only usePattern for pattern mode', async () => {
+      const grepScripts = jest.fn(async () => ({ content: [] }));
+      const fakeTools = { grepScripts } as unknown as RobloxStudioTools;
+
+      await TOOL_HANDLERS.grep_scripts(fakeTools, {
+        pattern: 'foo|bar',
+        isRegex: true,
+        instance_id: 'place:test',
+      });
+      expect(grepScripts).toHaveBeenLastCalledWith('foo|bar', expect.objectContaining({
+        usePattern: undefined,
+      }), 'place:test');
+
+      await TOOL_HANDLERS.grep_scripts(fakeTools, {
+        pattern: 'foo|bar',
+        usePattern: true,
+        instance_id: 'place:test',
+      });
+      expect(grepScripts).toHaveBeenLastCalledWith('foo|bar', expect.objectContaining({
+        usePattern: true,
+      }), 'place:test');
     });
   });
 

--- a/packages/core/src/__tests__/smoke.test.ts
+++ b/packages/core/src/__tests__/smoke.test.ts
@@ -701,6 +701,34 @@ describe('Smoke', () => {
     expect(tools.resolveImageId).not.toHaveBeenCalled();
   });
 
+  test('get_script_source shows plugin truncation range and note', async () => {
+    const bridge = new BridgeService();
+    const tools = new RobloxStudioTools(bridge);
+    bridge.registerInstance(READY);
+
+    const resultPromise = tools.getScriptSource('game.ServerScriptService.Manager', undefined, undefined, 'place:test');
+    const pending = bridge.getPendingRequest('place:test', 'edit');
+    expect(pending?.request.endpoint).toBe('/api/get-script-source');
+    bridge.resolveRequest(pending!.requestId, {
+      success: true,
+      instancePath: 'game.ServerScriptService.Manager',
+      className: 'Script',
+      topService: 'ServerScriptService',
+      lineCount: 1700,
+      startLine: 1,
+      endLine: 300,
+      truncated: true,
+      note: 'Truncated to first 300 lines; use line_range to read more.',
+      numberedSource: '1  print("start")\n300 print("still here")',
+    });
+
+    const result = await resultPromise;
+    const text = result.content[0].text;
+    expect(text).toContain('Lines:    1700 total (showing 1-300)');
+    expect(text).toContain('Note:     Truncated to first 300 lines; use line_range to read more.');
+    expect(text).not.toContain('Truncated to first 1000 lines');
+  });
+
   test('start_playtest reports already running when runtime peers are connected', async () => {
     const bridge = new BridgeService();
     const tools = new RobloxStudioTools(bridge);
@@ -1103,6 +1131,158 @@ describe('Smoke', () => {
       clientRoles: ['client-1'],
       playerCount: 1,
     });
+  });
+
+  test('multiplayer_playtest start requires force before launching hazardous StudioTestService sessions', async () => {
+    const bridge = new BridgeService();
+    const tools = new RobloxStudioTools(bridge);
+    bridge.registerInstance(READY);
+
+    const result = await tools.multiplayerPlaytest('start', 1, undefined, undefined, undefined, 1, 'place:test');
+    const body = JSON.parse(result.content[0].text);
+
+    expect(body).toMatchObject({
+      success: false,
+      action: 'start',
+      error: 'multiplayer_force_required',
+      requiresForce: true,
+      manualCleanupRequired: true,
+    });
+    expect(bridge.getPendingRequest('place:test', 'edit')).toBeNull();
+  });
+
+  test('multiplayer_playtest forced start waits for detected server and client peers', async () => {
+    const bridge = new BridgeService();
+    const tools = new RobloxStudioTools(bridge) as any;
+    tools._buildMultiplayerState = async () => ({
+      peers: [{ role: 'edit' }, { role: 'server' }, { role: 'client-1' }],
+      clientRoles: ['client-1'],
+      playerCount: 1,
+    });
+    bridge.registerInstance(READY);
+
+    const resultPromise = tools.multiplayerPlaytest('start', 1, undefined, undefined, undefined, 2, 'place:test', true);
+    const pending = bridge.getPendingRequest('place:test', 'edit');
+    expect(pending?.request).toMatchObject({
+      endpoint: '/api/multiplayer-test-start',
+      data: { numPlayers: 1, testArgs: {} },
+    });
+    bridge.resolveRequest(pending!.requestId, {
+      success: true,
+      message: 'Multiplayer Studio test starting with 1 player(s).',
+    });
+    bridge.registerInstance({
+      pluginSessionId: 'server-1',
+      instanceId: 'place:test',
+      role: 'server',
+      placeId: 0,
+      placeName: 'Game',
+      dataModelName: 'Game',
+      isRunning: true,
+    });
+    bridge.registerInstance({
+      pluginSessionId: 'client-1',
+      instanceId: 'place:test',
+      role: 'client',
+      placeId: 0,
+      placeName: 'Game',
+      dataModelName: 'Game',
+      isRunning: true,
+    });
+
+    const result = await resultPromise;
+    const body = JSON.parse(result.content[0].text);
+    expect(body).toMatchObject({
+      success: true,
+      action: 'start',
+      ready: true,
+      manualCleanupRequired: true,
+      roles: expect.arrayContaining(['edit', 'server', 'client-1']),
+    });
+  });
+
+  test('multiplayer start reports failure when peers are not detected before timeout', async () => {
+    const bridge = new BridgeService();
+    const tools = new RobloxStudioTools(bridge) as any;
+    tools._buildMultiplayerState = async () => ({
+      peers: [{ role: 'edit' }],
+      clientRoles: [],
+      playerCount: 0,
+    });
+    bridge.registerInstance(READY);
+
+    const resultPromise = tools.multiplayerPlaytest('start', 1, undefined, undefined, undefined, 0.1, 'place:test', true);
+    const pending = bridge.getPendingRequest('place:test', 'edit');
+    bridge.resolveRequest(pending!.requestId, {
+      success: true,
+      message: 'Multiplayer Studio test starting with 1 player(s).',
+    });
+
+    const result = await resultPromise;
+    const body = JSON.parse(result.content[0].text);
+    expect(body).toMatchObject({
+      success: false,
+      action: 'start',
+      error: 'multiplayer_start_not_detected',
+      manualCleanupRequired: true,
+    });
+  });
+
+  test('multiplayer stop/end is disabled and does not call EndTest', async () => {
+    const bridge = new BridgeService();
+    const tools = new RobloxStudioTools(bridge);
+    bridge.registerInstance(READY);
+    bridge.registerInstance({
+      pluginSessionId: 'server-1',
+      instanceId: 'place:test',
+      role: 'server',
+      placeId: 0,
+      placeName: 'Game',
+      dataModelName: 'Game',
+      isRunning: true,
+    });
+
+    const wrapperResult = await tools.multiplayerPlaytest('end', undefined, undefined, undefined, 'done', 1, 'place:test');
+    const wrapperBody = JSON.parse(wrapperResult.content[0].text);
+    expect(wrapperBody).toMatchObject({
+      success: false,
+      action: 'end',
+      error: 'multiplayer_stop_disabled',
+      manualCleanupRequired: true,
+    });
+
+    const rawResult = await tools.multiplayerTestEnd('done', 1, 'place:test');
+    const rawBody = JSON.parse(rawResult.content[0].text);
+    expect(rawBody).toMatchObject({
+      success: false,
+      error: 'multiplayer_stop_disabled',
+      manualCleanupRequired: true,
+    });
+    expect(bridge.getPendingRequest('place:test', 'server')).toBeNull();
+  });
+
+  test('multiplayer start keeps waiting when edit phase completes before peers register', async () => {
+    const bridge = new BridgeService();
+    const tools = new RobloxStudioTools(bridge) as any;
+    const exactChecks = jest.fn()
+      .mockResolvedValueOnce({ ok: false, roles: ['edit'], timedOut: true })
+      .mockResolvedValueOnce({ ok: true, roles: ['edit', 'server', 'client-1'], timedOut: false });
+    tools._waitForExactClientCount = exactChecks;
+    tools.client = {
+      request: jest.fn(async () => ({
+        session: { phase: 'completed' },
+      })),
+    };
+
+    const result = await tools._waitForMultiplayerStart('place:test', 1, 1);
+
+    expect(result).toEqual({
+      ok: true,
+      roles: ['edit', 'server', 'client-1'],
+      timedOut: false,
+      error: undefined,
+    });
+    expect(exactChecks).toHaveBeenCalledTimes(2);
   });
 
   test('get_scene_analysis fans out to connected peers', async () => {

--- a/packages/core/src/__tests__/tool-schema.test.ts
+++ b/packages/core/src/__tests__/tool-schema.test.ts
@@ -54,6 +54,7 @@ describe('Tool schema compatibility', () => {
 
     const multiplayerProps = (TOOL_DEFINITIONS.find(tool => tool.name === 'multiplayer_playtest')!.inputSchema as { properties?: Record<string, any>; required?: string[] }).properties ?? {};
     expect((multiplayerProps.action as { enum?: string[] }).enum).toEqual(['start', 'status', 'add_players', 'leave_client', 'end']);
+    expect(multiplayerProps.force).toMatchObject({ type: 'boolean' });
     expect((TOOL_DEFINITIONS.find(tool => tool.name === 'multiplayer_playtest')!.inputSchema as { required?: string[] }).required).toEqual(['action']);
 
     for (const name of [
@@ -69,6 +70,46 @@ describe('Tool schema compatibility', () => {
       expect(deprecatedNames.has(name)).toBe(true);
       expect(callableNames.has(name)).toBe(true);
     }
+
+    const deprecatedStartProps = (DEPRECATED_TOOL_DEFINITIONS.find(tool => tool.name === 'multiplayer_test_start')!.inputSchema as { properties?: Record<string, any> }).properties ?? {};
+    expect(deprecatedStartProps.force).toMatchObject({ type: 'boolean' });
+  });
+
+  test('grep_scripts exposes one explicit pattern-mode switch', () => {
+    const grep = TOOL_DEFINITIONS.find(tool => tool.name === 'grep_scripts')!;
+    const props = (grep.inputSchema as { properties?: Record<string, any> }).properties ?? {};
+
+    expect(props.usePattern).toMatchObject({ type: 'boolean' });
+    expect(props.isRegex).toBeUndefined();
+    expect(props.caseSensitive.description).toContain('Lua pattern mode is always case-sensitive');
+  });
+
+  test('get_script_source exposes only line_range for range selection', () => {
+    const tool = TOOL_DEFINITIONS.find(tool => tool.name === 'get_script_source');
+    expect(tool).toBeDefined();
+    const props = (tool!.inputSchema as { properties?: Record<string, unknown> }).properties ?? {};
+
+    expect(Object.keys(props).sort()).toEqual(['instancePath', 'instance_id', 'line_range']);
+    expect(props).not.toHaveProperty('startLine');
+    expect(props).not.toHaveProperty('endLine');
+    expect(props).not.toHaveProperty('lineRange');
+  });
+
+  test('script line tools expose line_range instead of startLine/endLine', () => {
+    for (const name of ['edit_script_lines', 'delete_script_lines']) {
+      const tool = TOOL_DEFINITIONS.find(tool => tool.name === name);
+      expect(tool).toBeDefined();
+      const schema = tool!.inputSchema as { properties?: Record<string, unknown>; required?: string[] };
+      const props = schema.properties ?? {};
+
+      expect(props).toHaveProperty('line_range');
+      expect(props).not.toHaveProperty('startLine');
+      expect(props).not.toHaveProperty('endLine');
+      expect(props).not.toHaveProperty('lineRange');
+    }
+
+    const deleteRequired = (TOOL_DEFINITIONS.find(tool => tool.name === 'delete_script_lines')!.inputSchema as { required?: string[] }).required ?? [];
+    expect(deleteRequired).toEqual(['instancePath', 'line_range']);
   });
 
   // Tools that don't dispatch to Studio (asset uploads, local file ops, build

--- a/packages/core/src/http-server.ts
+++ b/packages/core/src/http-server.ts
@@ -22,35 +22,59 @@ interface StreamableHttpConfig {
 
 export type ToolHandler = (tools: RobloxStudioTools, body: any) => Promise<any>;
 
+type ParsedLineRange = {
+  startLine?: number;
+  endLine?: number;
+};
+
 /**
- * Normalize a convenience `lineRange` value into [startLine, endLine].
- * Accepts an array ([start, end]), a single number, or a string such as
- * "100-200", "100:200", open-ended "100-" / "-200", or a single "42".
+ * Normalize a line_range string into internal [startLine, endLine] coordinates.
+ * Accepts "100-200", "100:200", open-ended "100-" / "-200", or a single "42".
  * Returns undefined when nothing usable is present.
  */
-export function parseLineRange(lineRange: unknown): [number | undefined, number | undefined] | undefined {
-  if (Array.isArray(lineRange)) {
-    const s = typeof lineRange[0] === 'number' ? lineRange[0] : undefined;
-    const e = typeof lineRange[1] === 'number' ? lineRange[1] : undefined;
-    return s !== undefined || e !== undefined ? [s, e] : undefined;
-  }
-  if (typeof lineRange === 'number') {
-    return [lineRange, lineRange];
-  }
+export function parseLineRange(lineRange: unknown): ParsedLineRange | undefined {
+  const validLine = (line: number | undefined) => line === undefined || line >= 1;
   if (typeof lineRange === 'string') {
     const ranged = lineRange.match(/^\s*(\d+)?\s*[-:]\s*(\d+)?\s*$/);
     if (ranged) {
       const s = ranged[1] !== undefined ? parseInt(ranged[1], 10) : undefined;
       const e = ranged[2] !== undefined ? parseInt(ranged[2], 10) : undefined;
-      if (s !== undefined || e !== undefined) return [s, e];
+      if (!validLine(s) || !validLine(e)) return undefined;
+      if (s !== undefined && e !== undefined && s > e) return undefined;
+      if (s !== undefined || e !== undefined) return { startLine: s, endLine: e };
     }
     const single = lineRange.match(/^\s*(\d+)\s*$/);
     if (single) {
       const n = parseInt(single[1], 10);
-      return [n, n];
+      if (n < 1) return undefined;
+      return { startLine: n, endLine: n };
     }
   }
   return undefined;
+}
+
+function optionalLineRange(body: any, toolName: string): ParsedLineRange {
+  if (body.line_range === undefined) return {};
+  const parsed = parseLineRange(body.line_range);
+  if (!parsed) throw new Error(`${toolName} line_range must be a string like "42", "10-20", "10-", or "-20"`);
+  return parsed;
+}
+
+function optionalLineAnchor(body: any, toolName: string): number | undefined {
+  const parsed = optionalLineRange(body, toolName);
+  if (parsed.startLine === undefined && parsed.endLine === undefined) return undefined;
+  if (parsed.startLine === undefined || parsed.endLine === undefined || parsed.endLine !== parsed.startLine) {
+    throw new Error(`${toolName} line_range must be a single line like "42"`);
+  }
+  return parsed.startLine;
+}
+
+function requiredClosedLineRange(body: any, toolName: string): { startLine: number; endLine: number } {
+  const parsed = optionalLineRange(body, toolName);
+  if (parsed.startLine === undefined || parsed.endLine === undefined) {
+    throw new Error(`${toolName} requires line_range as "start-end" or a single line like "42"`);
+  }
+  return { startLine: parsed.startLine, endLine: parsed.endLine };
 }
 
 export const TOOL_HANDLERS: Record<string, ToolHandler> = {
@@ -75,8 +99,7 @@ export const TOOL_HANDLERS: Record<string, ToolHandler> = {
   mass_duplicate: (tools, body) => tools.massDuplicate(body.duplications, body.instance_id),
   grep_scripts: (tools, body) => tools.grepScripts(body.pattern, {
     caseSensitive: body.caseSensitive,
-    // `isRegex` is an accepted alias for `usePattern` (Lua pattern matching).
-    usePattern: body.usePattern ?? body.isRegex,
+    usePattern: body.usePattern,
     contextLines: body.contextLines,
     maxResults: body.maxResults,
     maxResultsPerScript: body.maxResultsPerScript,
@@ -85,22 +108,16 @@ export const TOOL_HANDLERS: Record<string, ToolHandler> = {
     classFilter: body.classFilter,
   }, body.instance_id),
   get_script_source: (tools, body) => {
-    let startLine = body.startLine;
-    let endLine = body.endLine;
-    // Accept a convenience `lineRange` when explicit start/end aren't provided.
-    if (startLine === undefined && endLine === undefined && body.lineRange !== undefined) {
-      const parsed = parseLineRange(body.lineRange);
-      if (parsed) {
-        startLine = parsed[0];
-        endLine = parsed[1];
-      }
-    }
+    const { startLine, endLine } = optionalLineRange(body, 'get_script_source');
     return tools.getScriptSource(body.instancePath, startLine, endLine, body.instance_id);
   },
   set_script_source: (tools, body) => tools.setScriptSource(body.instancePath, body.source, body.instance_id),
-  edit_script_lines: (tools, body) => tools.editScriptLines(body.instancePath, body.old_string, body.new_string, body.startLine, body.instance_id),
+  edit_script_lines: (tools, body) => tools.editScriptLines(body.instancePath, body.old_string, body.new_string, optionalLineAnchor(body, 'edit_script_lines'), body.instance_id),
   insert_script_lines: (tools, body) => tools.insertScriptLines(body.instancePath, body.afterLine, body.newContent, body.instance_id),
-  delete_script_lines: (tools, body) => tools.deleteScriptLines(body.instancePath, body.startLine, body.endLine, body.instance_id),
+  delete_script_lines: (tools, body) => {
+    const { startLine, endLine } = requiredClosedLineRange(body, 'delete_script_lines');
+    return tools.deleteScriptLines(body.instancePath, startLine, endLine, body.instance_id);
+  },
   set_attribute: (tools, body) => tools.setAttribute(body.instancePath, body.attributeName, body.attributeValue, body.valueType, body.instance_id),
   get_attributes: (tools, body) => tools.getAttributes(body.instancePath, body.instance_id),
   delete_attribute: (tools, body) => tools.deleteAttribute(body.instancePath, body.attributeName, body.instance_id),
@@ -122,8 +139,8 @@ export const TOOL_HANDLERS: Record<string, ToolHandler> = {
   solo_playtest: (tools, body) => tools.soloPlaytest(body.action, body.mode, body.timeout, body.instance_id),
   start_playtest: (tools, body) => tools.startPlaytest(body.mode, body.numPlayers, body.instance_id),
   stop_playtest: (tools, body) => tools.stopPlaytest(body.instance_id),
-  multiplayer_playtest: (tools, body) => tools.multiplayerPlaytest(body.action, body.numPlayers, body.target, body.testArgs, body.value, body.timeout, body.instance_id),
-  multiplayer_test_start: (tools, body) => tools.multiplayerTestStart(body.numPlayers, body.testArgs, body.timeout, body.instance_id),
+  multiplayer_playtest: (tools, body) => tools.multiplayerPlaytest(body.action, body.numPlayers, body.target, body.testArgs, body.value, body.timeout, body.instance_id, body.force),
+  multiplayer_test_start: (tools, body) => tools.multiplayerTestStart(body.numPlayers, body.testArgs, body.timeout, body.instance_id, body.force),
   multiplayer_test_state: (tools, body) => tools.multiplayerTestState(body.instance_id),
   multiplayer_test_add_players: (tools, body) => tools.multiplayerTestAddPlayers(body.numPlayers, body.timeout, body.instance_id),
   multiplayer_test_leave_client: (tools, body) => tools.multiplayerTestLeaveClient(body.target, body.timeout, body.instance_id),

--- a/packages/core/src/http-server.ts
+++ b/packages/core/src/http-server.ts
@@ -22,6 +22,37 @@ interface StreamableHttpConfig {
 
 export type ToolHandler = (tools: RobloxStudioTools, body: any) => Promise<any>;
 
+/**
+ * Normalize a convenience `lineRange` value into [startLine, endLine].
+ * Accepts an array ([start, end]), a single number, or a string such as
+ * "100-200", "100:200", open-ended "100-" / "-200", or a single "42".
+ * Returns undefined when nothing usable is present.
+ */
+export function parseLineRange(lineRange: unknown): [number | undefined, number | undefined] | undefined {
+  if (Array.isArray(lineRange)) {
+    const s = typeof lineRange[0] === 'number' ? lineRange[0] : undefined;
+    const e = typeof lineRange[1] === 'number' ? lineRange[1] : undefined;
+    return s !== undefined || e !== undefined ? [s, e] : undefined;
+  }
+  if (typeof lineRange === 'number') {
+    return [lineRange, lineRange];
+  }
+  if (typeof lineRange === 'string') {
+    const ranged = lineRange.match(/^\s*(\d+)?\s*[-:]\s*(\d+)?\s*$/);
+    if (ranged) {
+      const s = ranged[1] !== undefined ? parseInt(ranged[1], 10) : undefined;
+      const e = ranged[2] !== undefined ? parseInt(ranged[2], 10) : undefined;
+      if (s !== undefined || e !== undefined) return [s, e];
+    }
+    const single = lineRange.match(/^\s*(\d+)\s*$/);
+    if (single) {
+      const n = parseInt(single[1], 10);
+      return [n, n];
+    }
+  }
+  return undefined;
+}
+
 export const TOOL_HANDLERS: Record<string, ToolHandler> = {
   get_file_tree: (tools, body) => tools.getFileTree(body.path, body.instance_id),
   search_files: (tools, body) => tools.searchFiles(body.query, body.searchType, body.instance_id),
@@ -44,7 +75,8 @@ export const TOOL_HANDLERS: Record<string, ToolHandler> = {
   mass_duplicate: (tools, body) => tools.massDuplicate(body.duplications, body.instance_id),
   grep_scripts: (tools, body) => tools.grepScripts(body.pattern, {
     caseSensitive: body.caseSensitive,
-    usePattern: body.usePattern,
+    // `isRegex` is an accepted alias for `usePattern` (Lua pattern matching).
+    usePattern: body.usePattern ?? body.isRegex,
     contextLines: body.contextLines,
     maxResults: body.maxResults,
     maxResultsPerScript: body.maxResultsPerScript,
@@ -52,7 +84,19 @@ export const TOOL_HANDLERS: Record<string, ToolHandler> = {
     path: body.path,
     classFilter: body.classFilter,
   }, body.instance_id),
-  get_script_source: (tools, body) => tools.getScriptSource(body.instancePath, body.startLine, body.endLine, body.instance_id),
+  get_script_source: (tools, body) => {
+    let startLine = body.startLine;
+    let endLine = body.endLine;
+    // Accept a convenience `lineRange` when explicit start/end aren't provided.
+    if (startLine === undefined && endLine === undefined && body.lineRange !== undefined) {
+      const parsed = parseLineRange(body.lineRange);
+      if (parsed) {
+        startLine = parsed[0];
+        endLine = parsed[1];
+      }
+    }
+    return tools.getScriptSource(body.instancePath, startLine, endLine, body.instance_id);
+  },
   set_script_source: (tools, body) => tools.setScriptSource(body.instancePath, body.source, body.instance_id),
   edit_script_lines: (tools, body) => tools.editScriptLines(body.instancePath, body.old_string, body.new_string, body.startLine, body.instance_id),
   insert_script_lines: (tools, body) => tools.insertScriptLines(body.instancePath, body.afterLine, body.newContent, body.instance_id),

--- a/packages/core/src/tools/definitions.ts
+++ b/packages/core/src/tools/definitions.ts
@@ -552,7 +552,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'get_script_source',
     category: 'read',
-    description: 'Get script source. Returns "source" and "numberedSource" (line-numbered). Pass a range for large scripts via startLine/endLine or the lineRange shorthand; without a range, large scripts are truncated (see the "truncated" flag and "note") to avoid flooding the context.',
+    description: 'Get script source. Returns "source" and "numberedSource" (line-numbered). Pass line_range for large scripts; without a range, large scripts are truncated (see the "truncated" flag and "note") to avoid flooding the context.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -560,17 +560,9 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           type: 'string',
           description: 'Canonical path to a LuaSourceContainer'
         },
-        startLine: {
-          type: 'number',
-          description: 'Start line (1-indexed)'
-        },
-        endLine: {
-          type: 'number',
-          description: 'End line (inclusive)'
-        },
-        lineRange: {
+        line_range: {
           type: 'string',
-          description: 'Shorthand for startLine/endLine: "start-end" (e.g. "100-200"), open-ended ("100-" or "-200"), or a single line ("42"). Ignored when startLine/endLine are provided.'
+          description: 'Line range to return: "start-end" (e.g. "100-200"), open-ended ("100-" or "-200"), or a single line ("42").'
         },
         instance_id: {
           type: 'string',
@@ -606,7 +598,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'edit_script_lines',
     category: 'write',
-    description: 'Replace exact text in a script. Without startLine, old_string must match exactly once in the script. Pass startLine (1-indexed, from get_script_source) to anchor the edit to a specific line when old_string is ambiguous (e.g. repeated closing braces).',
+    description: 'Replace exact text in a script. Without line_range, old_string must match exactly once in the script. Pass line_range as a single line (e.g. "42") to anchor the edit when old_string is ambiguous.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -616,15 +608,15 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         old_string: {
           type: 'string',
-          description: 'Exact text to find and replace. Must be unique in the script unless startLine is provided.'
+          description: 'Exact text to find and replace. Must be unique in the script unless line_range is provided.'
         },
         new_string: {
           type: 'string',
           description: 'Replacement text'
         },
-        startLine: {
-          type: 'number',
-          description: 'Optional 1-indexed line where old_string begins. When provided, skips uniqueness check and requires old_string to match starting at that exact line.'
+        line_range: {
+          type: 'string',
+          description: 'Optional single line where old_string begins, such as "42". When provided, skips uniqueness check and requires old_string to match starting at that exact line.'
         },
         instance_id: {
           type: 'string',
@@ -664,7 +656,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'delete_script_lines',
     category: 'write',
-    description: 'Delete a range of lines. 1-indexed, inclusive.',
+    description: 'Delete a range of lines. line_range is 1-indexed and inclusive.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -672,20 +664,16 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           type: 'string',
           description: 'Canonical path to a LuaSourceContainer'
         },
-        startLine: {
-          type: 'number',
-          description: 'Start line (1-indexed)'
-        },
-        endLine: {
-          type: 'number',
-          description: 'End line (inclusive)'
+        line_range: {
+          type: 'string',
+          description: 'Line range to delete: "start-end" (e.g. "100-200") or a single line ("42"). Open-ended ranges are not accepted for deletion.'
         },
         instance_id: {
           type: 'string',
           description: 'Which connected Studio place to target. Required when multiple places are connected; omit when one. Use get_connected_instances to list available IDs.'
         }
       },
-      required: ['instancePath', 'startLine', 'endLine']
+      required: ['instancePath', 'line_range']
     }
   },
 
@@ -942,19 +930,15 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       properties: {
         pattern: {
           type: 'string',
-          description: 'Search pattern. Literal by default; with usePattern/isRegex it is a Lua pattern with top-level "|" alternation (e.g. "foo|bar").'
+          description: 'Search text. Literal by default; with usePattern=true it is a case-sensitive Lua pattern with top-level "|" alternation (e.g. "foo|bar").'
         },
         caseSensitive: {
           type: 'boolean',
-          description: 'Case-sensitive search (default: false)'
+          description: 'Literal search case sensitivity (default: false). Lua pattern mode is always case-sensitive; passing false with usePattern=true is rejected.'
         },
         usePattern: {
           type: 'boolean',
-          description: 'Use Lua pattern matching instead of literal (default: false). Supports top-level alternation: "a|b" matches a line containing "a" or "b". Note: Lua patterns are NOT PCRE — use %d/%a/%w classes and ".-" (not ".*?"); ^ $ ( ) . % + - * ? [ ] are magic.'
-        },
-        isRegex: {
-          type: 'boolean',
-          description: 'Alias for usePattern. Enables Lua pattern matching with top-level "|" alternation.'
+          description: 'Use case-sensitive Lua pattern matching instead of literal search (default: false). Supports top-level alternation: "a|b" matches a line containing "a" or "b". Note: Lua patterns are NOT PCRE — use %d/%a/%w classes and ".-" (not ".*?"); ^ $ ( ) . % + - * ? [ ] are magic.'
         },
         contextLines: {
           type: 'number',
@@ -1356,7 +1340,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'multiplayer_playtest',
     category: 'write',
-    description: 'Start, inspect, add players to, remove a client from, or end a StudioTestService multiplayer playtest. Use action="start" with numPlayers, action="status", action="add_players" with numPlayers, action="leave_client" with target="client-N", or action="end". Returns brief lifecycle status only; read script output with get_runtime_logs.',
+    description: 'Start or inspect a StudioTestService multiplayer playtest. Use action="start" with numPlayers and force=true only when you accept that MCP cannot stop it and you must manually close the multiplayer test windows afterward. action="status" inspects state, action="add_players" adds players, and action="leave_client" removes one client. action="end" is disabled for now and returns the StudioTestService:EndTest broken-API reason. Returns brief lifecycle status only; read script output with get_runtime_logs.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1377,11 +1361,15 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
           description: 'For action="start": JSON-compatible table passed to StudioTestService:GetTestArgs() on server and clients.'
         },
         value: {
-          description: 'For action="end": JSON-compatible value returned to the edit-side ExecuteMultiplayerTestAsync call.'
+          description: 'Ignored while action="end" is disabled.'
+        },
+        force: {
+          type: 'boolean',
+          description: 'Required for action="start". Pass true only if you understand StudioTestService:EndTest is broken in this flow and you will manually close the multiplayer test windows.'
         },
         timeout: {
           type: 'number',
-          description: 'Max seconds to wait for action completion. Defaults to 30.'
+          description: 'Max seconds to wait for start peer detection or action completion. Defaults to 30.'
         },
         instance_id: {
           type: 'string',
@@ -2671,7 +2659,7 @@ export const DEPRECATED_TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'multiplayer_test_start',
     category: 'write',
-    description: 'Deprecated. Use multiplayer_playtest with action="start" instead. Starts a StudioTestService multiplayer test.',
+    description: 'Deprecated. Use multiplayer_playtest with action="start" instead. Starts a StudioTestService multiplayer test only when force=true acknowledges that MCP cannot stop it and the test windows must be closed manually.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -2682,6 +2670,10 @@ export const DEPRECATED_TOOL_DEFINITIONS: ToolDefinition[] = [
         testArgs: {
           description: 'JSON-compatible table passed to StudioTestService:GetTestArgs() on server and clients.'
         },
+        force: {
+          type: 'boolean',
+          description: 'Required. Pass true only if you understand StudioTestService:EndTest is broken in this flow and you will manually close the multiplayer test windows.'
+        },
         timeout: {
           type: 'number',
           description: 'Max seconds to wait for server + clients to register (default 30).'
@@ -2691,7 +2683,7 @@ export const DEPRECATED_TOOL_DEFINITIONS: ToolDefinition[] = [
           description: 'Which connected Studio place to target. Required when multiple places are connected; omit when one. Use get_connected_instances to list available IDs.'
         }
       },
-      required: ['numPlayers']
+      required: ['numPlayers', 'force']
     }
   },
   {
@@ -2756,16 +2748,16 @@ export const DEPRECATED_TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'multiplayer_test_end',
     category: 'write',
-    description: 'Deprecated. Use multiplayer_playtest with action="end" instead. Ends a running StudioTestService multiplayer test.',
+    description: 'Deprecated. Multiplayer StudioTestService stop/end is disabled for now because StudioTestService:EndTest is broken in this flow. This tool returns a disabled error and does not call EndTest.',
     inputSchema: {
       type: 'object',
       properties: {
         value: {
-          description: 'JSON-compatible value returned to the edit-side ExecuteMultiplayerTestAsync call.'
+          description: 'Ignored while multiplayer stop/end is disabled.'
         },
         timeout: {
           type: 'number',
-          description: 'Max seconds to wait for runtime peers to disconnect (default 30).'
+          description: 'Ignored while multiplayer stop/end is disabled.'
         },
         instance_id: {
           type: 'string',

--- a/packages/core/src/tools/definitions.ts
+++ b/packages/core/src/tools/definitions.ts
@@ -552,7 +552,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'get_script_source',
     category: 'read',
-    description: 'Get script source. Returns "source" and "numberedSource" (line-numbered). Use startLine/endLine for large scripts.',
+    description: 'Get script source. Returns "source" and "numberedSource" (line-numbered). Pass a range for large scripts via startLine/endLine or the lineRange shorthand; without a range, large scripts are truncated (see the "truncated" flag and "note") to avoid flooding the context.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -567,6 +567,10 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
         endLine: {
           type: 'number',
           description: 'End line (inclusive)'
+        },
+        lineRange: {
+          type: 'string',
+          description: 'Shorthand for startLine/endLine: "start-end" (e.g. "100-200"), open-ended ("100-" or "-200"), or a single line ("42"). Ignored when startLine/endLine are provided.'
         },
         instance_id: {
           type: 'string',
@@ -932,13 +936,13 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'grep_scripts',
     category: 'read',
-    description: 'Ripgrep-inspired search across all script sources. Supports literal and Lua pattern matching, context lines, early termination, and results grouped by script with line/column numbers.',
+    description: 'Ripgrep-inspired search across all script sources. Supports literal and Lua pattern matching (with top-level "|" alternation), context lines, early termination, and results grouped by script with line/column numbers.',
     inputSchema: {
       type: 'object',
       properties: {
         pattern: {
           type: 'string',
-          description: 'Search pattern (literal string or Lua pattern)'
+          description: 'Search pattern. Literal by default; with usePattern/isRegex it is a Lua pattern with top-level "|" alternation (e.g. "foo|bar").'
         },
         caseSensitive: {
           type: 'boolean',
@@ -946,7 +950,11 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         usePattern: {
           type: 'boolean',
-          description: 'Use Lua pattern matching instead of literal (default: false)'
+          description: 'Use Lua pattern matching instead of literal (default: false). Supports top-level alternation: "a|b" matches a line containing "a" or "b". Note: Lua patterns are NOT PCRE — use %d/%a/%w classes and ".-" (not ".*?"); ^ $ ( ) . % + - * ? [ ] are magic.'
+        },
+        isRegex: {
+          type: 'boolean',
+          description: 'Alias for usePattern. Enables Lua pattern matching with top-level "|" alternation.'
         },
         contextLines: {
           type: 'number',

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -62,6 +62,23 @@ const MAX_INLINE_IMAGE_BYTES = 6_000_000;
 const MAX_DEVICE_MATRIX_ENTRIES = 6;
 const MAX_NETWORK_PACKET_LOSS_PERCENT = 0.5;
 const STUDIO_ASSISTANT_SOURCE_IMAGE_LABEL = 'Studio Assistant Source Image';
+const MULTIPLAYER_FORCE_REQUIRED_MESSAGE =
+  'StudioTestService multiplayer stop is currently disabled because StudioTestService:EndTest is broken for this flow. ' +
+  'Pass force=true only if you understand you must manually close the multiplayer test windows afterward.';
+const MULTIPLAYER_STOP_DISABLED_MESSAGE =
+  'Multiplayer playtest stop/end is disabled because StudioTestService:EndTest is currently broken for this flow. ' +
+  'Manually close the Studio multiplayer test windows instead.';
+
+function multiplayerStopDisabledBody(): Record<string, unknown> {
+  return {
+    success: false,
+    error: 'multiplayer_stop_disabled',
+    message: MULTIPLAYER_STOP_DISABLED_MESSAGE,
+    reason: 'StudioTestService:EndTest does not reliably end StudioTestService multiplayer sessions from MCP right now.',
+    manualCleanupRequired: true,
+    recoveryHint: 'Close the Roblox Studio multiplayer test windows manually.',
+  };
+}
 
 // Encodes the raw RGBA capture into the requested image format.
 // - 'png': lossless — sharpest text/UI, but a busy 3D scene can be large.
@@ -1572,13 +1589,16 @@ export class RobloxStudioTools {
         : pathSegments[0] === 'game' ? (pathSegments[1] ?? 'game') : pathSegments[0];
     const typeNote = scriptTypeInfo[response.className as string] || (response.className as string);
     const serviceNote = serviceInfo[topService] || topService;
+    const showRange = Boolean(response.isPartial || response.truncated)
+      && response.startLine !== undefined
+      && response.endLine !== undefined;
 
     const headerLines: string[] = [
       `Path:     ${pathStr}`,
       `Type:     ${typeNote}`,
       `Location: ${serviceNote}`,
       `Lines:    ${response.lineCount} total${
-        response.isPartial ? ` (showing ${response.startLine}-${response.endLine})` : ''
+        showRange ? ` (showing ${response.startLine}-${response.endLine})` : ''
       }`,
     ];
 
@@ -1586,8 +1606,10 @@ export class RobloxStudioTools {
       headerLines.push(`Status:   DISABLED`);
     }
 
-    if (response.truncated) {
-      headerLines.push(`Note:     Truncated to first 1000 lines, use startLine/endLine to read more`);
+    if (typeof response.note === 'string' && response.note.length > 0) {
+      headerLines.push(`Note:     ${response.note}`);
+    } else if (response.truncated) {
+      headerLines.push(`Note:     Truncated response; use line_range to read more`);
     }
 
     const header = headerLines.join('\n');
@@ -1670,7 +1692,6 @@ export class RobloxStudioTools {
     options?: {
       caseSensitive?: boolean;
       usePattern?: boolean;
-      isRegex?: boolean;
       contextLines?: number;
       maxResults?: number;
       maxResultsPerScript?: number;
@@ -1683,12 +1704,9 @@ export class RobloxStudioTools {
     if (!pattern) {
       throw new Error('Pattern is required for grep_scripts');
     }
-    // `isRegex` is an accepted alias for `usePattern`.
-    const { isRegex, ...rest } = options ?? {};
     const response = await this._callSingle('/api/grep-scripts', {
       pattern,
-      ...rest,
-      usePattern: rest.usePattern ?? isRegex,
+      ...(options ?? {}),
     }, undefined, instance_id);
     return {
       content: [
@@ -3210,17 +3228,32 @@ export class RobloxStudioTools {
     instanceId: string,
     clientCount: number,
     timeoutSec = 30,
+    connectedAfter?: number,
   ): Promise<{ ok: boolean; roles: string[]; timedOut: boolean; phase?: string; error?: unknown }> {
     const deadline = Date.now() + timeoutSec * 1000;
+    let lastPhase: string | undefined;
     while (Date.now() < deadline) {
       const exact = await this._waitForExactClientCount(instanceId, clientCount, 0.25, 0);
       if (exact.ok || exact.extraClients) {
+        if (exact.ok && connectedAfter !== undefined) {
+          const instances = this.bridge.getInstances().filter((inst) => inst.instanceId === instanceId);
+          const freshRoles = new Set(instances.filter((inst) => inst.connectedAt >= connectedAfter).map((inst) => inst.role));
+          const freshClientCount = [...freshRoles].filter((role) => /^client-\d+$/.test(role)).length;
+          if (!freshRoles.has('server') || freshClientCount !== clientCount) {
+            await sleep(250);
+            continue;
+          }
+        }
         return { ok: exact.ok, roles: exact.roles, timedOut: false, error: exact.extraClients ? `Expected ${clientCount} client(s), but Studio registered ${exact.clientCount}.` : undefined };
       }
       try {
-        const editState = await this.client.request('/api/multiplayer-test-state', {}, instanceId, 'edit');
+        const remainingMs = Math.max(1, Math.min(1000, deadline - Date.now()));
+        const editState = await this.client.request('/api/multiplayer-test-state', {}, instanceId, 'edit', remainingMs);
         const session = editState?.session;
-        if (session?.phase === 'failed' || session?.phase === 'completed') {
+        if (typeof session?.phase === 'string') {
+          lastPhase = session.phase;
+        }
+        if (session?.phase === 'failed') {
           return { ok: false, roles: this._rolesForInstance(instanceId), timedOut: false, phase: session.phase, error: session.error };
         }
       } catch {
@@ -3228,7 +3261,7 @@ export class RobloxStudioTools {
       }
       await sleep(250);
     }
-    return { ok: false, roles: this._rolesForInstance(instanceId), timedOut: true };
+    return { ok: false, roles: this._rolesForInstance(instanceId), timedOut: true, phase: lastPhase };
   }
 
   async multiplayerPlaytest(
@@ -3239,6 +3272,7 @@ export class RobloxStudioTools {
     value?: unknown,
     timeout?: number,
     instance_id?: string,
+    force?: boolean,
   ) {
     if (
       action !== 'start' &&
@@ -3270,29 +3304,37 @@ export class RobloxStudioTools {
     }
 
     if (action === 'start') {
-      const body = this._parseTextResult(await this.multiplayerTestStart(numPlayers as number, testArgs, timeout, instance_id));
+      if (force !== true) {
+        return this._textResult({
+          success: false,
+          action,
+          error: 'multiplayer_force_required',
+          message: MULTIPLAYER_FORCE_REQUIRED_MESSAGE,
+          requiresForce: true,
+          manualCleanupRequired: true,
+        });
+      }
+
+      const body = this._parseTextResult(await this.multiplayerTestStart(numPlayers as number, testArgs, timeout, instance_id, force));
       const state = body.state && typeof body.state === 'object' ? body.state as Record<string, any> : {};
-      // The session is a success once it has launched, even if not every peer has
-      // registered yet (readiness). A false "timeout" while the test is actually
-      // running was a long-standing source of confusion.
-      const launched = body.success === true && (body.ready === true || body.launched === true);
+      const launched = body.success === true && body.ready === true;
       return this._textResult(launched ? {
         success: true,
         action,
-        message: body.ready === true
-          ? 'Multiplayer playtest started.'
-          : 'Multiplayer playtest launched; peers still registering. Use multiplayer_playtest action="status" to confirm readiness.',
-        ready: body.ready === true,
+        message: 'Multiplayer playtest started. Stop/end is disabled; close the multiplayer test windows manually when finished.',
+        ready: true,
+        manualCleanupRequired: true,
         roles: Array.isArray(body.roles) ? body.roles : undefined,
         clientRoles: Array.isArray(state.clientRoles) ? state.clientRoles : undefined,
         playerCount: typeof state.playerCount === 'number' ? state.playerCount : undefined,
       } : {
         success: false,
         action,
-        error: body.error ?? body.wait?.error ?? 'start_failed',
+        error: body.error ?? body.wait?.error ?? 'multiplayer_start_not_detected',
         message: body.success === true
-          ? 'Multiplayer playtest did not become ready before timeout.'
+          ? 'Multiplayer playtest start was requested, but MCP did not detect the required server/client peers before timeout. You may need to close the test windows manually.'
           : body.message ?? 'Multiplayer playtest did not start.',
+        manualCleanupRequired: body.startRequested === true || body.launched === true ? true : undefined,
         roles: Array.isArray(body.roles) ? body.roles : undefined,
       });
     }
@@ -3335,31 +3377,43 @@ export class RobloxStudioTools {
       });
     }
 
-    const body = this._parseTextResult(await this.multiplayerTestEnd(value, timeout, instance_id));
-    return this._textResult(body.success === true && body.ended === true ? {
-      success: true,
+    return this._textResult({
       action,
-      message: body.alreadyEnded === true
-        ? 'Multiplayer playtest already ended.'
-        : (body.teardownConfirmed === false
-          ? 'Multiplayer playtest end requested; teardown still in progress. Use multiplayer_playtest action="status" to confirm.'
-          : 'Multiplayer playtest ended.'),
-      teardownConfirmed: body.teardownConfirmed === true,
-    } : {
-      success: false,
-      action,
-      error: body.error ?? 'end_failed',
-      message: body.message ?? 'Multiplayer playtest did not end.',
-      roles: Array.isArray(body.roles) ? body.roles : undefined,
-      editDone: body.editDone === false ? false : undefined,
+      ...multiplayerStopDisabledBody(),
     });
   }
 
-  async multiplayerTestStart(numPlayers: number, testArgs?: unknown, timeout?: number, instance_id?: string) {
+  async multiplayerTestStart(numPlayers: number, testArgs?: unknown, timeout?: number, instance_id?: string, force?: boolean) {
     if (!Number.isInteger(numPlayers) || numPlayers < 1 || numPlayers > 8) {
       throw new Error('numPlayers must be an integer from 1 to 8');
     }
     const editTarget = this._resolveSingleTarget('edit', instance_id);
+    if (force !== true) {
+      return this._textResult({
+        success: false,
+        error: 'multiplayer_force_required',
+        message: MULTIPLAYER_FORCE_REQUIRED_MESSAGE,
+        requiresForce: true,
+        manualCleanupRequired: true,
+      });
+    }
+
+    const existingRuntime = this._runtimeTargetsForEquivalentInstances(editTarget.instanceId);
+    if (existingRuntime.length > 0) {
+      const roles = this._rolesForEquivalentInstances(editTarget.instanceId);
+      return this._textResult({
+        success: false,
+        error: 'Multiplayer playtest already running.',
+        message: 'A Studio runtime is already connected for this place. Close the existing playtest windows manually before starting another multiplayer playtest.',
+        ready: true,
+        timedOut: false,
+        roles,
+        runtimeRoles: existingRuntime.map((target) => target.role),
+        manualCleanupRequired: true,
+      });
+    }
+
+    const startedAt = Date.now();
     const response = await this.client.request(
       '/api/multiplayer-test-start',
       { numPlayers, testArgs: testArgs ?? {} },
@@ -3370,23 +3424,29 @@ export class RobloxStudioTools {
       return { content: [{ type: 'text', text: JSON.stringify(response) }] };
     }
 
-    const wait = await this._waitForMultiplayerStart(editTarget.instanceId, numPlayers, timeout ?? 60);
-    // A heavy place can take longer than the readiness window to register every
-    // peer; readiness timing out does NOT mean the test failed to launch. Treat
-    // an actually-running session as launched so callers don't see a false failure.
-    const launched = wait.ok || await this._isMultiplayerTestRunning(editTarget.instanceId);
+    const wait = await this._waitForMultiplayerStart(editTarget.instanceId, numPlayers, timeout ?? 60, startedAt);
+    const launched = wait.ok;
     const state = await this._buildMultiplayerState(editTarget.instanceId);
+    const success = response.success === true && wait.ok;
     return {
       content: [{
         type: 'text',
         text: JSON.stringify({
           ...response,
+          success,
           ready: wait.ok,
           launched,
+          startRequested: response.success === true,
           timedOut: wait.timedOut,
           wait,
           roles: wait.roles,
           state,
+          error: success ? undefined : wait.error ?? 'multiplayer_start_not_detected',
+          message: success
+            ? 'Multiplayer Studio test started and runtime peers detected.'
+            : 'Multiplayer Studio test start was requested, but MCP did not detect the required server/client peers before timeout. Close the multiplayer test windows manually if Studio launched them.',
+          manualCleanupRequired: success || response.success === true ? true : undefined,
+          startedAt,
         }),
       }],
     };
@@ -3465,67 +3525,10 @@ export class RobloxStudioTools {
   }
 
   async multiplayerTestEnd(value?: unknown, timeout?: number, instance_id?: string) {
-    let serverTarget: { instanceId: string; role: string };
-    try {
-      serverTarget = this._resolveSingleTarget('server', instance_id);
-    } catch (err) {
-      // No running server peer to receive EndTest. If no runtime peers remain at
-      // all, the multiplayer test is already torn down — report it ended rather
-      // than failing on target resolution.
-      const instanceId = this._resolveInstanceIdOnly(instance_id);
-      const hasRuntime = this._rolesForInstance(instanceId).some(
-        (role) => role === 'server' || /^client-\d+$/.test(role),
-      );
-      if (!hasRuntime) {
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: true,
-              ended: true,
-              alreadyEnded: true,
-              teardownConfirmed: true,
-              message: 'No active multiplayer test to end (already ended).',
-            }),
-          }],
-        };
-      }
-      throw err;
-    }
-    const response = await this.client.request(
-      '/api/multiplayer-test-end',
-      { value: value ?? 'ended_by_mcp' },
-      serverTarget.instanceId,
-      serverTarget.role,
-    );
-    if (response?.error) {
-      return { content: [{ type: 'text', text: JSON.stringify(response) }] };
-    }
-    const editDone = await this._waitForMultiplayerEditDone(serverTarget.instanceId, timeout ?? 30);
-    const wait = await this._waitForRuntimeRoles(
-      serverTarget.instanceId,
-      { noRuntime: true },
-      timeout ?? 30,
-    );
-    const state = await this._buildMultiplayerState(serverTarget.instanceId);
-    return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({
-          ...response,
-          // EndTest was accepted by the server peer => the test is ending. Full
-          // teardown (all runtime peers gone) is reported separately via
-          // teardownConfirmed and does NOT gate success, since teardown can
-          // outlast the wait window.
-          ended: response.success === true,
-          teardownConfirmed: wait.ok,
-          editDone,
-          timedOut: wait.timedOut,
-          roles: wait.roles,
-          state,
-        }),
-      }],
-    };
+    void value;
+    void timeout;
+    void instance_id;
+    return this._textResult(multiplayerStopDisabledBody());
   }
 
   async getConnectedInstances() {

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -1670,6 +1670,7 @@ export class RobloxStudioTools {
     options?: {
       caseSensitive?: boolean;
       usePattern?: boolean;
+      isRegex?: boolean;
       contextLines?: number;
       maxResults?: number;
       maxResultsPerScript?: number;
@@ -1682,9 +1683,12 @@ export class RobloxStudioTools {
     if (!pattern) {
       throw new Error('Pattern is required for grep_scripts');
     }
+    // `isRegex` is an accepted alias for `usePattern`.
+    const { isRegex, ...rest } = options ?? {};
     const response = await this._callSingle('/api/grep-scripts', {
       pattern,
-      ...options
+      ...rest,
+      usePattern: rest.usePattern ?? isRegex,
     }, undefined, instance_id);
     return {
       content: [
@@ -3268,11 +3272,17 @@ export class RobloxStudioTools {
     if (action === 'start') {
       const body = this._parseTextResult(await this.multiplayerTestStart(numPlayers as number, testArgs, timeout, instance_id));
       const state = body.state && typeof body.state === 'object' ? body.state as Record<string, any> : {};
-      const success = body.success === true && body.ready === true;
-      return this._textResult(success ? {
+      // The session is a success once it has launched, even if not every peer has
+      // registered yet (readiness). A false "timeout" while the test is actually
+      // running was a long-standing source of confusion.
+      const launched = body.success === true && (body.ready === true || body.launched === true);
+      return this._textResult(launched ? {
         success: true,
         action,
-        message: 'Multiplayer playtest started.',
+        message: body.ready === true
+          ? 'Multiplayer playtest started.'
+          : 'Multiplayer playtest launched; peers still registering. Use multiplayer_playtest action="status" to confirm readiness.',
+        ready: body.ready === true,
         roles: Array.isArray(body.roles) ? body.roles : undefined,
         clientRoles: Array.isArray(state.clientRoles) ? state.clientRoles : undefined,
         playerCount: typeof state.playerCount === 'number' ? state.playerCount : undefined,
@@ -3329,7 +3339,12 @@ export class RobloxStudioTools {
     return this._textResult(body.success === true && body.ended === true ? {
       success: true,
       action,
-      message: 'Multiplayer playtest ended.',
+      message: body.alreadyEnded === true
+        ? 'Multiplayer playtest already ended.'
+        : (body.teardownConfirmed === false
+          ? 'Multiplayer playtest end requested; teardown still in progress. Use multiplayer_playtest action="status" to confirm.'
+          : 'Multiplayer playtest ended.'),
+      teardownConfirmed: body.teardownConfirmed === true,
     } : {
       success: false,
       action,
@@ -3355,7 +3370,11 @@ export class RobloxStudioTools {
       return { content: [{ type: 'text', text: JSON.stringify(response) }] };
     }
 
-    const wait = await this._waitForMultiplayerStart(editTarget.instanceId, numPlayers, timeout ?? 30);
+    const wait = await this._waitForMultiplayerStart(editTarget.instanceId, numPlayers, timeout ?? 60);
+    // A heavy place can take longer than the readiness window to register every
+    // peer; readiness timing out does NOT mean the test failed to launch. Treat
+    // an actually-running session as launched so callers don't see a false failure.
+    const launched = wait.ok || await this._isMultiplayerTestRunning(editTarget.instanceId);
     const state = await this._buildMultiplayerState(editTarget.instanceId);
     return {
       content: [{
@@ -3363,6 +3382,7 @@ export class RobloxStudioTools {
         text: JSON.stringify({
           ...response,
           ready: wait.ok,
+          launched,
           timedOut: wait.timedOut,
           wait,
           roles: wait.roles,
@@ -3445,7 +3465,33 @@ export class RobloxStudioTools {
   }
 
   async multiplayerTestEnd(value?: unknown, timeout?: number, instance_id?: string) {
-    const serverTarget = this._resolveSingleTarget('server', instance_id);
+    let serverTarget: { instanceId: string; role: string };
+    try {
+      serverTarget = this._resolveSingleTarget('server', instance_id);
+    } catch (err) {
+      // No running server peer to receive EndTest. If no runtime peers remain at
+      // all, the multiplayer test is already torn down — report it ended rather
+      // than failing on target resolution.
+      const instanceId = this._resolveInstanceIdOnly(instance_id);
+      const hasRuntime = this._rolesForInstance(instanceId).some(
+        (role) => role === 'server' || /^client-\d+$/.test(role),
+      );
+      if (!hasRuntime) {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              ended: true,
+              alreadyEnded: true,
+              teardownConfirmed: true,
+              message: 'No active multiplayer test to end (already ended).',
+            }),
+          }],
+        };
+      }
+      throw err;
+    }
     const response = await this.client.request(
       '/api/multiplayer-test-end',
       { value: value ?? 'ended_by_mcp' },
@@ -3467,7 +3513,12 @@ export class RobloxStudioTools {
         type: 'text',
         text: JSON.stringify({
           ...response,
-          ended: wait.ok,
+          // EndTest was accepted by the server peer => the test is ending. Full
+          // teardown (all runtime peers gone) is reported separately via
+          // teardownConfirmed and does NOT gate success, since teardown can
+          // outlast the wait window.
+          ended: response.success === true,
+          teardownConfirmed: wait.ok,
           editDone,
           timedOut: wait.timedOut,
           roles: wait.roles,

--- a/studio-plugin/src/modules/ServerUrlSettings.ts
+++ b/studio-plugin/src/modules/ServerUrlSettings.ts
@@ -41,7 +41,7 @@ function addUnique(values: string[], value: string): void {
 	}
 }
 
-function computeInstanceIds(): string[] {
+function computeInstanceIds(options?: { createAnonymous?: boolean }): string[] {
 	const ids: string[] = [];
 	if (game.PlaceId !== 0) {
 		addUnique(ids, `place:${tostring(game.PlaceId)}`);
@@ -49,7 +49,7 @@ function computeInstanceIds(): string[] {
 	const existing = ServerStorage.GetAttribute("__MCPPlaceId");
 	if (typeIs(existing, "string") && existing !== "") {
 		addUnique(ids, `anon:${existing as string}`);
-	} else if (game.PlaceId === 0) {
+	} else if (game.PlaceId === 0 && options?.createAnonymous === true) {
 		const fresh = HttpService.GenerateGUID(false);
 		pcall(() => ServerStorage.SetAttribute("__MCPPlaceId", fresh));
 		addUnique(ids, `anon:${fresh}`);
@@ -83,7 +83,7 @@ function rememberServerUrl(serverUrl: string): void {
 	const normalized = normalizeServerUrl(serverUrl);
 	if (!pluginRef || normalized === "") return;
 	writeSettingString(GLOBAL_SETTING_KEY, normalized);
-	for (const instanceId of computeInstanceIds()) {
+	for (const instanceId of computeInstanceIds({ createAnonymous: true })) {
 		writeSettingString(settingKey(instanceId), normalized);
 		writeSettingString(legacySettingKey(instanceId), normalized);
 	}
@@ -91,6 +91,9 @@ function rememberServerUrl(serverUrl: string): void {
 
 function readServerUrl(): string | undefined {
 	if (!pluginRef) return undefined;
+	// Reading settings should not mint a place identity. Client play DMs have
+	// their own ServerStorage; creating an id there makes a misleading anon id
+	// that never matches the edit/server bridge identity.
 	for (const instanceId of computeInstanceIds()) {
 		const remembered = readSettingString(settingKey(instanceId));
 		if (remembered !== undefined) return remembered;

--- a/studio-plugin/src/modules/handlers/QueryHandlers.ts
+++ b/studio-plugin/src/modules/handlers/QueryHandlers.ts
@@ -564,6 +564,48 @@ function getProjectStructure(requestData: Record<string, unknown>) {
 	return result;
 }
 
+// Split a Lua pattern on TOP-LEVEL "|" into alternatives. Lua patterns have no
+// alternation operator, so "foo|bar" would otherwise be matched as the literal
+// text "foo|bar" and silently never hit. "%|" stays a literal pipe.
+function splitLuaAlternation(pattern: string): string[] {
+	const parts: string[] = [];
+	let current = "";
+	let i = 1;
+	const n = pattern.size();
+	while (i <= n) {
+		const c = string.sub(pattern, i, i);
+		if (c === "%") {
+			// Preserve an escape pair (e.g. %|, %., %d) intact.
+			current += string.sub(pattern, i, i + 1);
+			i += 2;
+		} else if (c === "|") {
+			parts.push(current);
+			current = "";
+			i += 1;
+		} else {
+			current += c;
+			i += 1;
+		}
+	}
+	parts.push(current);
+	return parts;
+}
+
+// Return the earliest match across alternatives (mirrors regex alternation).
+function findFirstPattern(line: string, alternatives: string[]): [number | undefined, number | undefined] {
+	let bestStart: number | undefined;
+	let bestEnd: number | undefined;
+	for (const alt of alternatives) {
+		if (alt === "") continue;
+		const [s, e] = string.find(line, alt);
+		if (s !== undefined && (bestStart === undefined || s < bestStart)) {
+			bestStart = s;
+			bestEnd = e as number;
+		}
+	}
+	return [bestStart, bestEnd];
+}
+
 function grepScripts(requestData: Record<string, unknown>) {
 	const pattern = requestData.pattern as string;
 	if (!pattern) return { error: "pattern is required" };
@@ -582,6 +624,8 @@ function grepScripts(requestData: Record<string, unknown>) {
 
 	// Prepare pattern for matching
 	const searchPattern = caseSensitive ? pattern : pattern.lower();
+	// Pre-split top-level "|" alternation once (pattern mode only).
+	const patternAlternatives = usePattern ? splitLuaAlternation(searchPattern) : undefined;
 
 	interface LineMatch {
 		line: number;
@@ -630,7 +674,7 @@ function grepScripts(requestData: Record<string, unknown>) {
 				let matchEnd: number | undefined;
 
 				if (usePattern) {
-					[matchStart, matchEnd] = string.find(searchLine, searchPattern);
+					[matchStart, matchEnd] = findFirstPattern(searchLine, patternAlternatives!);
 				} else {
 					[matchStart, matchEnd] = string.find(searchLine, searchPattern, 1, true);
 				}

--- a/studio-plugin/src/modules/handlers/QueryHandlers.ts
+++ b/studio-plugin/src/modules/handlers/QueryHandlers.ts
@@ -566,19 +566,34 @@ function getProjectStructure(requestData: Record<string, unknown>) {
 
 // Split a Lua pattern on TOP-LEVEL "|" into alternatives. Lua patterns have no
 // alternation operator, so "foo|bar" would otherwise be matched as the literal
-// text "foo|bar" and silently never hit. "%|" stays a literal pipe.
+// text "foo|bar" and silently never hit. "%|" stays a literal pipe, and "%bxy"
+// keeps both balanced-match delimiter characters.
 function splitLuaAlternation(pattern: string): string[] {
 	const parts: string[] = [];
 	let current = "";
 	let i = 1;
 	const n = pattern.size();
+	let inCharClass = false;
 	while (i <= n) {
 		const c = string.sub(pattern, i, i);
 		if (c === "%") {
+			if (string.sub(pattern, i + 1, i + 1) === "b") {
+				current += string.sub(pattern, i, math.min(i + 3, n));
+				i += 4;
+				continue;
+			}
 			// Preserve an escape pair (e.g. %|, %., %d) intact.
 			current += string.sub(pattern, i, i + 1);
 			i += 2;
-		} else if (c === "|") {
+		} else if (c === "[") {
+			inCharClass = true;
+			current += c;
+			i += 1;
+		} else if (c === "]") {
+			inCharClass = false;
+			current += c;
+			i += 1;
+		} else if (c === "|" && !inCharClass) {
 			parts.push(current);
 			current = "";
 			i += 1;
@@ -610,11 +625,17 @@ function grepScripts(requestData: Record<string, unknown>) {
 	const pattern = requestData.pattern as string;
 	if (!pattern) return { error: "pattern is required" };
 
-	const caseSensitive = (requestData.caseSensitive as boolean) ?? false;
+	const usePattern = (requestData.usePattern as boolean) ?? false;
+	if (usePattern && requestData.caseSensitive === false) {
+		return {
+			error: "Case-insensitive Lua pattern search is not supported. Omit caseSensitive or pass caseSensitive: true with usePattern: true, or use literal search.",
+		};
+	}
+
+	const caseSensitive = usePattern ? true : ((requestData.caseSensitive as boolean) ?? false);
 	const contextLines = (requestData.contextLines as number) ?? 0;
 	const maxResults = (requestData.maxResults as number) ?? 100;
 	const maxResultsPerScript = (requestData.maxResultsPerScript as number) ?? 0;
-	const usePattern = (requestData.usePattern as boolean) ?? false;
 	const filesOnly = (requestData.filesOnly as boolean) ?? false;
 	const searchPath = (requestData.path as string) ?? "";
 	const classFilter = requestData.classFilter as string | undefined;

--- a/studio-plugin/src/modules/handlers/ScriptHandlers.ts
+++ b/studio-plugin/src/modules/handlers/ScriptHandlers.ts
@@ -6,6 +6,10 @@ const ScriptEditorService = game.GetService("ScriptEditorService");
 const { getInstancePath, getInstanceByPath, readScriptSource, splitLines, joinLines } = Utils;
 const { beginRecording, finishRecording } = Recording;
 
+const SOURCE_TRUNCATE_CHAR_BUDGET = 25000;
+const SOURCE_TRUNCATE_LINE_BUDGET = 400;
+const SOURCE_TRUNCATE_TO_LINES = 300;
+
 function normalizeEscapes(s: string): string {
 	let result = s;
 	result = result.gsub("\\\\", "\x01")[0];
@@ -15,6 +19,30 @@ function normalizeEscapes(s: string): string {
 	result = result.gsub('\\"', '"')[0];
 	result = result.gsub("\x01", "\\")[0];
 	return result;
+}
+
+function getTopServiceName(instance: Instance): string {
+	let topServiceInst: Instance = instance;
+	while (topServiceInst.Parent && topServiceInst.Parent !== game) {
+		topServiceInst = topServiceInst.Parent;
+	}
+	return topServiceInst.Name;
+}
+
+function sliceLines(lines: string[], startLine: number, endLine: number): string[] {
+	const selectedLines: string[] = [];
+	for (let i = startLine; i <= endLine; i++) {
+		selectedLines.push(lines[i - 1] ?? "");
+	}
+	return selectedLines;
+}
+
+function numberLines(lines: string[], lineOffset: number): string {
+	const numberedLines: string[] = [];
+	for (let i = 0; i < lines.size(); i++) {
+		numberedLines.push(`${i + lineOffset}: ${lines[i]}`);
+	}
+	return numberedLines.join("\n");
 }
 
 function getScriptSource(requestData: Record<string, unknown>) {
@@ -34,85 +62,43 @@ function getScriptSource(requestData: Record<string, unknown>) {
 		const fullSource = readScriptSource(instance);
 		const [lines, hasTrailingNewline] = splitLines(fullSource);
 		const totalLineCount = lines.size();
-
-		let sourceToReturn = fullSource;
-		let returnedStartLine = 1;
-		let returnedEndLine = totalLineCount;
-
-		if (startLine !== undefined || endLine !== undefined) {
-			const actualStartLine = math.max(1, startLine ?? 1);
-			const actualEndLine = math.min(lines.size(), endLine ?? lines.size());
-
-			const selectedLines: string[] = [];
-			for (let i = actualStartLine; i <= actualEndLine; i++) {
-				selectedLines.push(lines[i - 1] ?? "");
-			}
-
-			sourceToReturn = selectedLines.join("\n");
-			if (hasTrailingNewline && actualEndLine === lines.size() && sourceToReturn.sub(-1) !== "\n") {
-				sourceToReturn += "\n";
-			}
-			returnedStartLine = actualStartLine;
-			returnedEndLine = actualEndLine;
-		}
-
-		const numberedLines: string[] = [];
-		const linesToNumber = startLine !== undefined ? splitLines(sourceToReturn)[0] : lines;
-		const lineOffset = returnedStartLine - 1;
-		for (let i = 0; i < linesToNumber.size(); i++) {
-			numberedLines.push(`${i + 1 + lineOffset}: ${linesToNumber[i]}`);
-		}
-		const numberedSource = numberedLines.join("\n");
+		const explicitRange = startLine !== undefined || endLine !== undefined;
+		const shouldTruncate = !explicitRange &&
+			(fullSource.size() > SOURCE_TRUNCATE_CHAR_BUDGET || totalLineCount > SOURCE_TRUNCATE_LINE_BUDGET);
+		const returnedStartLine = explicitRange ? math.max(1, startLine ?? 1) : 1;
+		const returnedEndLine = shouldTruncate
+			? math.min(SOURCE_TRUNCATE_TO_LINES, totalLineCount)
+			: explicitRange ? math.min(totalLineCount, endLine ?? totalLineCount) : totalLineCount;
+		const selectedLines = (explicitRange || shouldTruncate)
+			? sliceLines(lines, returnedStartLine, returnedEndLine)
+			: lines;
+		const sourceToReturn = explicitRange
+			? joinLines(selectedLines, hasTrailingNewline && returnedEndLine === totalLineCount)
+			: shouldTruncate ? selectedLines.join("\n") : fullSource;
 
 		const resp: Record<string, unknown> = {
 			instancePath,
 			className: instance.ClassName,
 			name: instance.Name,
 			source: sourceToReturn,
-			numberedSource,
+			numberedSource: numberLines(selectedLines, returnedStartLine),
 			sourceLength: fullSource.size(),
 			lineCount: totalLineCount,
 			startLine: returnedStartLine,
 			endLine: returnedEndLine,
-			isPartial: startLine !== undefined || endLine !== undefined,
-			truncated: false,
+			isPartial: explicitRange,
+			truncated: shouldTruncate,
 		};
 
-		// Safety cap for range-less reads: a whole large script easily exceeds
-		// the caller's token budget. Truncate on either a character OR a line
-		// budget so callers get a usable head instead of an oversized dump, and
-		// tell them how to read the rest.
-		const TRUNCATE_CHAR_BUDGET = 25000;
-		const TRUNCATE_LINE_BUDGET = 400;
-		const TRUNCATE_TO_LINES = 300;
-		if (
-			startLine === undefined &&
-			endLine === undefined &&
-			(fullSource.size() > TRUNCATE_CHAR_BUDGET || totalLineCount > TRUNCATE_LINE_BUDGET)
-		) {
-			const truncatedLines: string[] = [];
-			const truncatedNumberedLines: string[] = [];
-			const maxLines = math.min(TRUNCATE_TO_LINES, lines.size());
-			for (let i = 0; i < maxLines; i++) {
-				truncatedLines.push(lines[i]);
-				truncatedNumberedLines.push(`${i + 1}: ${lines[i]}`);
-			}
-			resp.source = truncatedLines.join("\n");
-			resp.numberedSource = truncatedNumberedLines.join("\n");
-			resp.truncated = true;
-			resp.endLine = maxLines;
-			resp.note = `Script truncated to first ${maxLines} of ${totalLineCount} lines (${fullSource.size()} chars). Use startLine/endLine (or the lineRange shorthand) to read specific sections.`;
+		if (shouldTruncate) {
+			resp.note = `Script truncated to first ${returnedEndLine} of ${totalLineCount} lines (${fullSource.size()} chars). Use line_range to read specific sections.`;
 		}
 
 		if (instance.IsA("BaseScript")) {
 			resp.enabled = instance.Enabled;
 		}
 
-		let topServiceInst: Instance = instance;
-		while (topServiceInst.Parent && topServiceInst.Parent !== game) {
-			topServiceInst = topServiceInst.Parent;
-		}
-		resp.topService = topServiceInst.Name;
+		resp.topService = getTopServiceName(instance);
 
 		return resp;
 	});

--- a/studio-plugin/src/modules/handlers/ScriptHandlers.ts
+++ b/studio-plugin/src/modules/handlers/ScriptHandlers.ts
@@ -78,10 +78,21 @@ function getScriptSource(requestData: Record<string, unknown>) {
 			truncated: false,
 		};
 
-		if (startLine === undefined && endLine === undefined && fullSource.size() > 50000) {
+		// Safety cap for range-less reads: a whole large script easily exceeds
+		// the caller's token budget. Truncate on either a character OR a line
+		// budget so callers get a usable head instead of an oversized dump, and
+		// tell them how to read the rest.
+		const TRUNCATE_CHAR_BUDGET = 25000;
+		const TRUNCATE_LINE_BUDGET = 400;
+		const TRUNCATE_TO_LINES = 300;
+		if (
+			startLine === undefined &&
+			endLine === undefined &&
+			(fullSource.size() > TRUNCATE_CHAR_BUDGET || totalLineCount > TRUNCATE_LINE_BUDGET)
+		) {
 			const truncatedLines: string[] = [];
 			const truncatedNumberedLines: string[] = [];
-			const maxLines = math.min(1000, lines.size());
+			const maxLines = math.min(TRUNCATE_TO_LINES, lines.size());
 			for (let i = 0; i < maxLines; i++) {
 				truncatedLines.push(lines[i]);
 				truncatedNumberedLines.push(`${i + 1}: ${lines[i]}`);
@@ -90,7 +101,7 @@ function getScriptSource(requestData: Record<string, unknown>) {
 			resp.numberedSource = truncatedNumberedLines.join("\n");
 			resp.truncated = true;
 			resp.endLine = maxLines;
-			resp.note = "Script truncated to first 1000 lines. Use startLine/endLine parameters to read specific sections.";
+			resp.note = `Script truncated to first ${maxLines} of ${totalLineCount} lines (${fullSource.size()} chars). Use startLine/endLine (or the lineRange shorthand) to read specific sections.`;
 		}
 
 		if (instance.IsA("BaseScript")) {

--- a/studio-plugin/src/modules/handlers/TestHandlers.ts
+++ b/studio-plugin/src/modules/handlers/TestHandlers.ts
@@ -322,20 +322,13 @@ function multiplayerTestLeaveClient(_requestData: Record<string, unknown>) {
 	};
 }
 
-function multiplayerTestEnd(requestData: Record<string, unknown>) {
-	if (!RunService.IsRunning() || !RunService.IsServer()) {
-		return { error: "multiplayer_test_end must be called on the running server peer. Route with target=server." };
-	}
-
-	const value = requestData.value !== undefined ? requestData.value : "ended_by_mcp";
-	const [ok, result] = pcall(() => StudioTestService.EndTest(value));
-	if (!ok) {
-		return { error: tostring(result) };
-	}
+function multiplayerTestEnd(_requestData: Record<string, unknown>) {
 	return {
-		success: true,
-		message: "Multiplayer Studio test end requested.",
-		value,
+		success: false,
+		error: "multiplayer_stop_disabled",
+		message: "Multiplayer playtest stop/end is disabled because StudioTestService:EndTest is currently broken for this flow. Manually close the Studio multiplayer test windows instead.",
+		reason: "StudioTestService:EndTest does not reliably end StudioTestService multiplayer sessions from MCP right now.",
+		manualCleanupRequired: true,
 	};
 }
 

--- a/studio-plugin/src/server/index.server.ts
+++ b/studio-plugin/src/server/index.server.ts
@@ -27,6 +27,8 @@ BreakpointHandlers.init(plugin);
 ServerUrlSettings.init(plugin);
 
 function applyRememberedServerUrl(): void {
+	if (ClientBroker.forkRole() === "client") return;
+
 	const rememberedServerUrl = ServerUrlSettings.readServerUrl();
 	if (rememberedServerUrl === undefined) return;
 


### PR DESCRIPTION
Fixes three issues hit during day-to-day use. Each is split across the core server and the Studio plugin where relevant.

## 1. `get_script_source` floods context on large scripts
**Symptom:** reading a large module (e.g. a ~1700-line `Manager`) returns the whole file, blowing the caller's token budget; the only escape was reading the spilled-to-disk result by offset.

**Cause:** the range-less safety truncation only triggered above **50 000 chars** and then still returned the first **1000** lines — far past a typical model context limit. There was also no ergonomic single-arg way to ask for a slice; `startLine`/`endLine` are easy to miss.

**Fix:**
- Truncate range-less reads on a char **or** line budget (`> 25 000` chars or `> 400` lines → first **300** lines), with a `note` telling the caller how to read the rest. (`studio-plugin/.../ScriptHandlers.ts`)
- Accept a `lineRange` shorthand — `"100-200"`, open-ended `"100-"` / `"-200"`, or a single `"42"` — mapped to `startLine`/`endLine`. (`http-server.ts`, schema in `definitions.ts`)

## 2. `grep_scripts` silently returns 0 hits for alternation
**Symptom:** with pattern mode on, `foo|bar` matches nothing.

**Cause:** pattern mode uses Lua `string.find`, and **Lua patterns have no `|` alternation** — `foo|bar` is matched as the literal text `foo|bar`, which silently never hits.

**Fix:**
- Support **top-level `|` alternation** in pattern mode by splitting the pattern on unescaped `|` (escaped `%|` stays literal; `%`-escapes like `%d`/`%%` are preserved) and matching the earliest alternative. (`studio-plugin/.../QueryHandlers.ts`)
- Accept `isRegex` as an alias for `usePattern`, and document that patterns are Lua patterns (not PCRE) in the schema. (`http-server.ts`, `index.ts`, `definitions.ts`)

## 3. `multiplayer_playtest` reports false `timeout` on start, and `end` looks like it fails
**Symptom:** `action="start"` frequently reports a timeout even though the test launched; `action="end"` reports failure even though the session ends.

**Cause:** both verdicts were gated on peer-registration detection inside a fixed window. `start` required every peer to register within the readiness timeout; `end` required full runtime teardown within the wait window. On heavier places those signals legitimately lag past the window, so a launched/ended session was reported as a failure.

**Fix (`index.ts`):**
- `start`: report success once the session has **actually launched** (`_isMultiplayerTestRunning`) even if not all peers have registered; surface `ready` separately and bump the default readiness window 30→60s.
- `end`: treat the operation as successful once **EndTest is accepted** by the server peer; report full teardown separately via `teardownConfirmed` (it no longer gates success). Resolving an already-torn-down session now reports `alreadyEnded` instead of throwing on target resolution.

## Testing
- `npm run typecheck`, `npm run compile:plugin` (roblox-ts), and `npm run build:all` all pass.
- `npm test`: 131/132 pass; the one failure (`generate_model` image upload) is pre-existing and unrelated — it requires `ROBLOX_CREATOR_USER_ID` in the environment.
- Pure logic (`lineRange` parsing, alternation splitting incl. escaped pipe and `%`-classes) unit-checked.
- The `multiplayer_playtest` changes are reporting/robustness improvements verified by code reasoning + typecheck; I could not exercise them against a live multiplayer StudioTestService session.
