### PR TITLE
Fix cookie-auth image uploads

### DIFF
--- a/packages/core/src/__tests__/roblox-cookie-client.test.ts
+++ b/packages/core/src/__tests__/roblox-cookie-client.test.ts
@@ -1,0 +1,157 @@
+import { RobloxCookieClient } from '../roblox-cookie-client.js';
+
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+  });
+}
+
+describe('RobloxCookieClient asset uploads', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('uploads an Image through user-auth and polls the operation with CSRF retry', async () => {
+    const fetchMock = jest.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('', {
+        status: 403,
+        headers: { 'x-csrf-token': 'csrf-token' },
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        path: 'operations/upload-123',
+        operationId: 'upload-123',
+        done: false,
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        path: 'operations/upload-123',
+        operationId: 'upload-123',
+        done: true,
+        response: { assetId: '987654321' },
+      }));
+
+    const client = new RobloxCookieClient('cookie-value');
+    const result = await client.uploadImage({
+      fileContent: Buffer.from('png data'),
+      fileName: 'reference.png',
+      displayName: 'Reference',
+      description: 'Reference image',
+      userId: '12345',
+    });
+
+    expect(result).toEqual({ assetId: 987654321 });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://apis.roblox.com/assets/user-auth/v1/assets',
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://apis.roblox.com/assets/user-auth/v1/assets',
+    );
+    expect(fetchMock.mock.calls[2][0]).toBe(
+      'https://apis.roblox.com/assets/user-auth/v1/operations/upload-123',
+    );
+
+    const retryHeaders = fetchMock.mock.calls[1][1]?.headers as Record<string, string>;
+    expect(retryHeaders.Cookie).toBe('.ROBLOSECURITY=cookie-value');
+    expect(retryHeaders['X-CSRF-TOKEN']).toBe('csrf-token');
+
+    const formData = fetchMock.mock.calls[1][1]?.body as FormData;
+    expect(JSON.parse(String(formData.get('request')))).toEqual({
+      assetType: 'Image',
+      displayName: 'Reference',
+      description: 'Reference image',
+      creationContext: { creator: { userId: '12345' } },
+    });
+    const fileContent = formData.get('fileContent') as Blob & { name: string };
+    expect(fileContent.name).toBe('reference.png');
+    expect(fileContent.type).toBe('image/png');
+  });
+
+  test('resolves the authenticated user when no creator ID is configured', async () => {
+    const fetchMock = jest.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({
+        id: 24680,
+        name: 'Builder',
+        displayName: 'Builder',
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        path: 'operations/upload-456',
+        operationId: 'upload-456',
+        done: true,
+        response: { assetId: '11223344' },
+      }));
+
+    const client = new RobloxCookieClient('cookie-value');
+    const result = await client.uploadImage({
+      fileContent: Buffer.from('jpeg data'),
+      fileName: 'texture.jpg',
+      displayName: 'Texture',
+      description: '',
+    });
+
+    expect(result).toEqual({ assetId: 11223344 });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://users.roblox.com/v1/users/authenticated',
+    );
+    const formData = fetchMock.mock.calls[1][1]?.body as FormData;
+    expect(JSON.parse(String(formData.get('request')))).toMatchObject({
+      creationContext: { creator: { userId: '24680' } },
+    });
+  });
+
+  test('uses group ownership when both creator IDs are provided', async () => {
+    const fetchMock = jest.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({
+        path: 'operations/upload-789',
+        operationId: 'upload-789',
+        done: true,
+        response: { assetId: 55667788 },
+      }));
+
+    const client = new RobloxCookieClient('cookie-value');
+    await client.uploadImage({
+      fileContent: Buffer.from('image data'),
+      fileName: 'group-image.bmp',
+      displayName: 'Group Image',
+      description: '',
+      userId: '12345',
+      groupId: '67890',
+    });
+
+    const formData = fetchMock.mock.calls[0][1]?.body as FormData;
+    expect(JSON.parse(String(formData.get('request'))).creationContext).toEqual({
+      creator: { groupId: '67890' },
+    });
+  });
+
+  test('surfaces operation failures', async () => {
+    jest.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({
+        path: 'operations/upload-failed',
+        operationId: 'upload-failed',
+        done: false,
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        path: 'operations/upload-failed',
+        operationId: 'upload-failed',
+        done: true,
+        error: { code: 7, message: 'Asset moderation rejected the upload' },
+      }));
+
+    const client = new RobloxCookieClient('cookie-value');
+    await expect(client.uploadImage({
+      fileContent: Buffer.from('image data'),
+      fileName: 'rejected.tga',
+      displayName: 'Rejected',
+      description: '',
+      userId: '12345',
+    })).rejects.toThrow('Image upload failed: Asset moderation rejected the upload');
+  });
+});

--- a/packages/core/src/__tests__/smoke.test.ts
+++ b/packages/core/src/__tests__/smoke.test.ts
@@ -1952,6 +1952,31 @@ describe('Smoke', () => {
     }
   });
 
+  test('generate_model source image cookie upload uses the direct Image asset id', async () => {
+    const bridge = new BridgeService();
+    const tools = new RobloxStudioTools(bridge) as any;
+    tools.cookieClient = {
+      hasCookie: () => true,
+      uploadImage: jest.fn(async () => ({ assetId: 888 })),
+    };
+    tools.openCloudClient = { hasApiKey: () => false };
+
+    const imageId = await tools.uploadGenerateModelReferenceImage(
+      Buffer.from('not actually png'),
+      'place:test',
+    );
+
+    expect(imageId).toBe(888);
+    expect(tools.cookieClient.uploadImage).toHaveBeenCalledWith({
+      fileContent: expect.any(Buffer),
+      fileName: 'generate-model-reference.png',
+      displayName: 'Studio Assistant Source Image',
+      description: 'Studio Assistant Source Image',
+      userId: process.env.ROBLOX_CREATOR_USER_ID,
+      groupId: process.env.ROBLOX_CREATOR_GROUP_ID,
+    });
+  });
+
   test('get_script_source shows plugin truncation range and note', async () => {
     const bridge = new BridgeService();
     const tools = new RobloxStudioTools(bridge);

--- a/packages/core/src/roblox-cookie-client.ts
+++ b/packages/core/src/roblox-cookie-client.ts
@@ -1,3 +1,29 @@
+export interface CookieImageUploadOptions {
+  fileContent: Buffer;
+  fileName: string;
+  displayName: string;
+  description: string;
+  userId?: string;
+  groupId?: string;
+}
+
+interface UserAuthAssetOperation {
+  path?: string;
+  operationId?: string;
+  done?: boolean;
+  response?: {
+    assetId?: string | number;
+    code?: string | number;
+    message?: string;
+  };
+  error?: {
+    code?: string | number;
+    message?: string;
+  };
+  code?: string | number;
+  message?: string;
+}
+
 export class RobloxCookieClient {
   private cookie: string;
   private csrfToken: string | null = null;
@@ -37,49 +63,155 @@ export class RobloxCookieClient {
     return response;
   }
 
-  async uploadDecal(
-    fileContent: Buffer,
-    name: string,
-    description: string
-  ): Promise<{ assetId: number; backingAssetId: number }> {
+  async uploadImage(options: CookieImageUploadOptions): Promise<{ assetId: number }> {
     if (!this.cookie) {
       throw new Error('ROBLOSECURITY cookie is not set.');
     }
 
-    const encodedName = encodeURIComponent(name);
-    const encodedDesc = encodeURIComponent(description);
-    const url = `https://data.roblox.com/data/upload/json?assetTypeId=13&name=${encodedName}&description=${encodedDesc}`;
+    const creator = await this.resolveCreator(options.userId, options.groupId);
+    const request = {
+      assetType: 'Image',
+      displayName: options.displayName,
+      description: options.description,
+      creationContext: { creator },
+    };
+    const formData = new FormData();
+    formData.append('request', JSON.stringify(request));
+    formData.append(
+      'fileContent',
+      new Blob(
+        [new Uint8Array(options.fileContent)],
+        { type: this.getImageMimeType(options.fileName) },
+      ),
+      options.fileName,
+    );
 
-    const response = await this.fetchWithCsrf(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/octet-stream',
-        'User-Agent': 'RobloxStudio/WinInet',
-        Requester: 'Client',
+    const response = await this.fetchWithCsrf(
+      'https://apis.roblox.com/assets/user-auth/v1/assets',
+      {
+        method: 'POST',
+        body: formData,
       },
-      body: new Uint8Array(fileContent),
-    });
+    );
+    const operation = await this.readOperation(response, 'Image upload');
+    return { assetId: await this.completeOperation(operation) };
+  }
 
+  private async resolveCreator(
+    userId?: string,
+    groupId?: string,
+  ): Promise<{ userId: string } | { groupId: string }> {
+    if (groupId) return { groupId };
+    if (userId) return { userId };
+
+    const response = await this.fetchWithCsrf(
+      'https://users.roblox.com/v1/users/authenticated',
+    );
     if (!response.ok) {
       const body = await response.text();
-      throw new Error(`Decal upload failed (${response.status}): ${body}`);
+      throw new Error(`Failed to resolve authenticated Roblox user (${response.status}): ${body}`);
     }
 
-    const result = await response.json() as {
-      Success: boolean;
-      AssetId?: number;
-      BackingAssetId?: number;
-      Message?: string;
-    };
+    const authenticatedUser = await response.json() as { id?: number | string };
+    const resolvedUserId = String(authenticatedUser.id ?? '');
+    if (!/^\d+$/.test(resolvedUserId) || resolvedUserId === '0') {
+      throw new Error('Authenticated Roblox user response did not include a valid user ID.');
+    }
+    return { userId: resolvedUserId };
+  }
 
-    if (!result.Success || !result.AssetId) {
-      throw new Error(`Decal upload failed: ${result.Message || 'Unknown error'}`);
+  private getImageMimeType(fileName: string): string {
+    const extension = fileName.split('.').pop()?.toLowerCase();
+    const mimeTypes: Record<string, string> = {
+      png: 'image/png',
+      jpg: 'image/jpeg',
+      jpeg: 'image/jpeg',
+      bmp: 'image/bmp',
+      tga: 'image/tga',
+    };
+    const mimeType = extension ? mimeTypes[extension] : undefined;
+    if (mimeType) return mimeType;
+    throw new Error(
+      `Unsupported image format: .${extension ?? '(none)'}. Supported: png/jpg/jpeg/bmp/tga`,
+    );
+  }
+
+  private async readOperation(
+    response: Response,
+    action: string,
+  ): Promise<UserAuthAssetOperation> {
+    const body = await response.text();
+    if (!response.ok) {
+      throw new Error(`${action} failed (${response.status}): ${body}`);
     }
 
-    return {
-      assetId: result.AssetId,
-      backingAssetId: result.BackingAssetId || 0,
-    };
+    try {
+      return JSON.parse(body) as UserAuthAssetOperation;
+    } catch {
+      throw new Error(`${action} returned malformed JSON: ${body}`);
+    }
+  }
+
+  private operationAssetId(operation: UserAuthAssetOperation): number | null {
+    const rawAssetId = operation.response?.assetId;
+    if (rawAssetId === undefined) return null;
+    const assetId = Number(rawAssetId);
+    if (!Number.isSafeInteger(assetId) || assetId <= 0) {
+      throw new Error(`Image upload returned an invalid asset ID: ${String(rawAssetId)}`);
+    }
+    return assetId;
+  }
+
+  private operationError(operation: UserAuthAssetOperation): string | null {
+    if (operation.error?.message) return operation.error.message;
+    if (operation.response?.message && operation.response.assetId === undefined) {
+      return operation.response.message;
+    }
+    if (operation.message) return operation.message;
+    return null;
+  }
+
+  private async completeOperation(operation: UserAuthAssetOperation): Promise<number> {
+    const initialError = this.operationError(operation);
+    if (initialError) throw new Error(`Image upload failed: ${initialError}`);
+
+    const initialAssetId = this.operationAssetId(operation);
+    if (initialAssetId !== null) return initialAssetId;
+    if (operation.done) {
+      throw new Error('Image upload completed without an asset ID.');
+    }
+
+    const operationId = operation.operationId ?? operation.path?.split('/').pop();
+    if (!operationId) {
+      throw new Error('Image upload response did not include an operation ID.');
+    }
+    return this.pollOperation(operationId);
+  }
+
+  private async pollOperation(
+    operationId: string,
+    maxAttempts = 30,
+    intervalMs = 2000,
+  ): Promise<number> {
+    const url = `https://apis.roblox.com/assets/user-auth/v1/operations/${encodeURIComponent(operationId)}`;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const response = await this.fetchWithCsrf(url);
+      const operation = await this.readOperation(response, 'Image upload status');
+      const operationError = this.operationError(operation);
+      if (operationError) throw new Error(`Image upload failed: ${operationError}`);
+
+      const assetId = this.operationAssetId(operation);
+      if (assetId !== null) return assetId;
+      if (operation.done) {
+        throw new Error('Image upload completed without an asset ID.');
+      }
+      if (attempt < maxAttempts - 1) {
+        await new Promise(resolve => setTimeout(resolve, intervalMs));
+      }
+    }
+    throw new Error(
+      `Image upload timed out after ${(maxAttempts * intervalMs) / 1000}s. Operation ID: ${operationId}`,
+    );
   }
 
   async getAssetDetails(

--- a/packages/core/src/tools/definitions.ts
+++ b/packages/core/src/tools/definitions.ts
@@ -2236,7 +2236,7 @@ part(0,2,0,2,1,1,"b")`,
   {
     name: 'upload_asset',
     category: 'write',
-    description: 'Upload any supported asset type to Roblox: Audio (mp3/ogg/wav/flac), Decal (png/jpg/bmp/tga), Model (fbx/gltf/glb/rbxm/rbxmx), Animation (rbxm/rbxmx), or Video (mp4/mov). Decal supports ROBLOSECURITY cookie auth or ROBLOX_OPEN_CLOUD_API_KEY. All other types require Open Cloud API key with asset:write scope + creator ID. Audio: max 7 min, 100 uploads/month (ID-verified). Video: max 5 min, requires 13+ ID-verified.',
+    description: 'Upload any supported asset type to Roblox: Audio (mp3/ogg/wav/flac), Decal (png/jpg/bmp/tga), Model (fbx/gltf/glb/rbxm/rbxmx), Animation (rbxm/rbxmx), or Video (mp4/mov). Decal supports ROBLOSECURITY cookie auth through the Asset Manager user-auth API and returns the direct Image asset ID, or ROBLOX_OPEN_CLOUD_API_KEY. All other types require Open Cloud API key with asset:write scope + creator ID. Audio: max 7 min, 100 uploads/month (ID-verified). Video: max 5 min, requires 13+ ID-verified.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -4685,15 +4685,15 @@ export class RobloxStudioTools {
     instance_id?: string,
   ): Promise<number> {
     if (this.cookieClient.hasCookie()) {
-      const result = await this.cookieClient.uploadDecal(
-        imageContent,
-        STUDIO_ASSISTANT_SOURCE_IMAGE_LABEL,
-        STUDIO_ASSISTANT_SOURCE_IMAGE_LABEL,
-      );
-      if (result.backingAssetId && result.backingAssetId > 0) {
-        return result.backingAssetId;
-      }
-      return this.resolveUploadedReferenceImageId(String(result.assetId), instance_id);
+      const result = await this.cookieClient.uploadImage({
+        fileContent: imageContent,
+        fileName: 'generate-model-reference.png',
+        displayName: STUDIO_ASSISTANT_SOURCE_IMAGE_LABEL,
+        description: STUDIO_ASSISTANT_SOURCE_IMAGE_LABEL,
+        userId: process.env.ROBLOX_CREATOR_USER_ID,
+        groupId: process.env.ROBLOX_CREATOR_GROUP_ID,
+      });
+      return result.assetId;
     }
 
     if (!this.openCloudClient.hasApiKey()) {
@@ -4749,9 +4749,18 @@ export class RobloxStudioTools {
 
     const fileContent = fs.readFileSync(filePath);
     const fileName = path.basename(filePath);
+    const resolvedGroupId = groupId || process.env.ROBLOX_CREATOR_GROUP_ID;
+    const resolvedUserId = userId || process.env.ROBLOX_CREATOR_USER_ID;
 
     if (assetType === 'Decal' && this.cookieClient.hasCookie()) {
-      const result = await this.cookieClient.uploadDecal(fileContent, displayName, description || '');
+      const result = await this.cookieClient.uploadImage({
+        fileContent,
+        fileName,
+        displayName,
+        description: description || '',
+        userId: resolvedUserId,
+        groupId: resolvedGroupId,
+      });
       return {
         content: [{
           type: 'text',
@@ -4760,9 +4769,9 @@ export class RobloxStudioTools {
             response: {
               assetId: String(result.assetId),
               displayName,
-              assetType,
-              decalId: String(result.assetId),
-              imageId: String(result.backingAssetId),
+              assetType: 'Image',
+              decalId: null,
+              imageId: String(result.assetId),
             },
           })
         }]
@@ -4777,9 +4786,6 @@ export class RobloxStudioTools {
         `No auth configured for ${assetType} upload. Set ROBLOX_OPEN_CLOUD_API_KEY (needs asset:write scope).${cookieHint}`
       );
     }
-
-    const resolvedGroupId = groupId || process.env.ROBLOX_CREATOR_GROUP_ID;
-    const resolvedUserId = userId || process.env.ROBLOX_CREATOR_USER_ID;
 
     if (!resolvedUserId && !resolvedGroupId) {
       throw new Error(


### PR DESCRIPTION
## Summary
- replace the legacy `data.roblox.com` Decal cookie upload with the Asset Manager user-auth API
- preserve CSRF retry and user/group ownership, resolve the authenticated user when no creator ID is configured, and poll upload operations to completion
- use the direct Image asset ID for cookie-auth `upload_asset` and `generate_model` reference images
- add regression coverage for CSRF retry, operation polling, creator selection, failures, and the generate-model path

## Validation
- `npm run typecheck`
- `npm run build`
- `npm test -w packages/core -- --runInBand src/__tests__/roblox-cookie-client.test.ts src/__tests__/smoke.test.ts` (93 tests)
- `npx eslint packages/core/src/roblox-cookie-client.ts packages/core/src/__tests__/roblox-cookie-client.test.ts`