### PR TITLE
Add selection tool: one view/get/set lifecycle with camera framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ screenshots, memory reports, and profiler captures from each peer.
 
 - Run Luau in Studio's edit context with `execute_luau`.
 - Use `set_properties` for instance properties and `find_and_replace_in_scripts` for script text. For project-specific bulk edits, use `execute_luau`.
+- Use `selection` to inspect or update Studio selection and frame a part or model before capturing the viewport.
 - Capture the viewport with `capture_screenshot`, then send mouse or keyboard input.
 
 ### Inspect Creator Store assets
@@ -95,7 +96,10 @@ On Windows, wrap with `cmd /c` if `npx` doesn't resolve:
 
 [![NPM Version](https://img.shields.io/npm/v/@chrrxs/robloxstudio-mcp-inspector)](https://www.npmjs.com/package/@chrrxs/robloxstudio-mcp-inspector)
 
-24 Studio-safe inspection tools: no DataModel or script edits. Export and profiler tools can still write files only to explicit local paths. Install only one variant at a time (the installers remove the other automatically):
+24 Studio-safe inspection tools: no DataModel or script edits. The selection
+tool can change editor selection and camera framing; export and profiler tools
+can write files only to explicit local paths. Install only one variant at a time
+(the installers remove the other automatically):
 
 ```bash
 claude mcp add robloxstudio-inspector -- npx -y @chrrxs/robloxstudio-mcp-inspector@latest --auto-install-plugin

--- a/docs/deprecated-api.md
+++ b/docs/deprecated-api.md
@@ -11,6 +11,7 @@ catalog. Update exact-name integrations as follows:
 | `multiplayer_test_add_players` | `multiplayer_playtest` with `action: "add_players"` |
 | `multiplayer_test_leave_client` | `multiplayer_playtest` with `action: "leave_client"` |
 | `multiplayer_test_end` | `multiplayer_playtest` with `action: "end"` |
+| `get_selection` | `selection` with `action: "get"` |
 | `get_file_tree` | `get_project_structure` |
 | `search_files` | `search_objects` for instances; `grep_scripts` for source |
 | `search_by_property` | `search_objects` with `searchType: "property"` |

--- a/docs/token-efficiency.md
+++ b/docs/token-efficiency.md
@@ -4,12 +4,6 @@ Version 3.0 treats the MCP wire surface as a budgeted public API.
 
 ## Catalog budget
 
-The 2.23.1 catalog contained 81 advertised tools and serialized to 95,892
-characters (about 23,973 tokens using the deliberately simple `characters / 4`
-estimate). The 3.0 catalog contains 47 canonical tools and serializes to 42,839
-characters (about 10,710 estimated tokens), a 55.3% reduction. The 24-tool
-inspector catalog serializes to 19,461 characters (about 4,865 estimated tokens).
-
 The regression test caps the serialized public catalog at 43,000 characters,
 tool descriptions at 120 characters, and argument descriptions at 64 characters.
 It also requires structured output schemas for every tool except the
@@ -30,9 +24,8 @@ API decision.
   `robloxstudio://tool-guides`. Official engine references remain available through
   the `robloxdocs://` resource templates.
 
-The shared server instructions are 978 characters and are advertised once. The
-5,305-character tool guide is not part of the tool catalog and is read only when
-needed.
+The server advertises shared instructions once. Clients read the detailed tool
+guide only when needed, and the guide is not part of the tool catalog.
 
 ## Response contract
 

--- a/docs/token-efficiency.md
+++ b/docs/token-efficiency.md
@@ -6,9 +6,9 @@ Version 3.0 treats the MCP wire surface as a budgeted public API.
 
 The 2.23.1 catalog contained 81 advertised tools and serialized to 95,892
 characters (about 23,973 tokens using the deliberately simple `characters / 4`
-estimate). The 3.0 catalog contains 47 canonical tools and serializes to 42,671
-characters (about 10,668 estimated tokens), a 55.5% reduction. The 24-tool
-inspector catalog serializes to 19,032 characters (about 4,758 estimated tokens).
+estimate). The 3.0 catalog contains 47 canonical tools and serializes to 42,839
+characters (about 10,710 estimated tokens), a 55.3% reduction. The 24-tool
+inspector catalog serializes to 19,461 characters (about 4,865 estimated tokens).
 
 The regression test caps the serialized public catalog at 43,000 characters,
 tool descriptions at 120 characters, and argument descriptions at 64 characters.
@@ -30,8 +30,8 @@ API decision.
   `robloxstudio://tool-guides`. Official engine references remain available through
   the `robloxdocs://` resource templates.
 
-The shared server instructions are 876 characters and are advertised once. The
-4,855-character tool guide is not part of the tool catalog and is read only when
+The shared server instructions are 978 characters and are advertised once. The
+5,305-character tool guide is not part of the tool catalog and is read only when
 needed.
 
 ## Response contract

--- a/packages/core/src/__tests__/http-security.test.ts
+++ b/packages/core/src/__tests__/http-security.test.ts
@@ -43,9 +43,9 @@ describe('HTTP security', () => {
       const app = createHttpServer(tools, bridge, undefined, undefined, {
         allowedOrigins: ['http://localhost:5173'],
       });
-      const ok = await request(app).options('/mcp/get_selection').set('Origin', 'http://localhost:5173');
+      const ok = await request(app).options('/mcp/selection').set('Origin', 'http://localhost:5173');
       expect(ok.status).toBe(204);
-      const bad = await request(app).options('/mcp/get_selection').set('Origin', 'https://evil.example');
+      const bad = await request(app).options('/mcp/selection').set('Origin', 'https://evil.example');
       expect(bad.status).toBe(403);
     });
   });
@@ -66,7 +66,7 @@ describe('HTTP security', () => {
       }
       const instances = await request(app).get('/instances');
       expect(instances.status).toBe(401);
-      const tool = await request(app).post('/mcp/get_selection').send({});
+      const tool = await request(app).post('/mcp/selection').send({});
       expect(tool.status).toBe(401);
     });
 

--- a/packages/core/src/__tests__/http-server.test.ts
+++ b/packages/core/src/__tests__/http-server.test.ts
@@ -240,6 +240,29 @@ describe('HTTP Server', () => {
       expect(multiplayerPlaytest).toHaveBeenLastCalledWith('start', 2, undefined, undefined, undefined, 5, 'place:test');
     });
 
+    test('selection handler forwards the lifecycle action and options together', async () => {
+      const selection = jest.fn(async () => ({ content: [] }));
+      const fakeTools = { selection } as unknown as RobloxStudioTools;
+
+      await TOOL_HANDLERS.selection(fakeTools, {
+        action: 'view',
+        path: 'game.Workspace.Subject',
+        padding: 1.25,
+        instance_id: 'place:test',
+      });
+
+      expect(selection).toHaveBeenLastCalledWith(
+        'view',
+        expect.objectContaining({
+          action: 'view',
+          path: 'game.Workspace.Subject',
+          padding: 1.25,
+          instance_id: 'place:test',
+        }),
+        'place:test',
+      );
+    });
+
     test('grep_scripts uses only usePattern for pattern mode', async () => {
       const grepScripts = jest.fn(async () => ({ content: [] }));
       const fakeTools = { grepScripts } as unknown as RobloxStudioTools;

--- a/packages/core/src/__tests__/mcp-runtime.test.ts
+++ b/packages/core/src/__tests__/mcp-runtime.test.ts
@@ -98,6 +98,10 @@ describe('MCP v2 tool runtime', () => {
     expect(catalog.every((tool) => tool.description.length <= 120)).toBe(true);
     expect(inspectorCatalog).toHaveLength(24);
     expect(JSON.stringify(inspectorCatalog).length).toBeLessThanOrEqual(20_000);
+    expect(byName.get('selection')?.outputSchema).toEqual({
+      type: 'object',
+      additionalProperties: true,
+    });
 
     for (const removed of [
       'start_playtest',

--- a/packages/core/src/__tests__/mcp-runtime.test.ts
+++ b/packages/core/src/__tests__/mcp-runtime.test.ts
@@ -90,11 +90,14 @@ describe('MCP v2 tool runtime', () => {
     const names = new Set(catalog.map((tool) => tool.name));
     const byName = new Map(catalog.map((tool) => [tool.name, tool]));
     const serialized = JSON.stringify(catalog);
+    const inspectorCatalog = getReadOnlyTools().map(publicToolDefinition);
 
     expect(catalog).toHaveLength(47);
     expect(serialized.length).toBeLessThanOrEqual(43_000);
     expect(catalog.filter((tool) => tool.outputSchema)).toHaveLength(46);
     expect(catalog.every((tool) => tool.description.length <= 120)).toBe(true);
+    expect(inspectorCatalog).toHaveLength(24);
+    expect(JSON.stringify(inspectorCatalog).length).toBeLessThanOrEqual(20_000);
 
     for (const removed of [
       'start_playtest',
@@ -138,6 +141,9 @@ describe('MCP v2 tool runtime', () => {
       'get_tagged',
       'undo',
       'redo',
+      'get_selection',
+      'set_selection',
+      'focus_viewport',
     ]) {
       expect(names.has(removed)).toBe(false);
       expect(TOOL_HANDLERS[removed]).toBeUndefined();
@@ -177,6 +183,12 @@ describe('MCP v2 tool runtime', () => {
     }
     expect(byName.get('edit_script_lines')?.annotations.idempotentHint).toBe(false);
     expect(byName.get('find_and_replace_in_scripts')?.annotations.idempotentHint).toBe(false);
+    expect(byName.get('selection')?.annotations).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
   });
 
   test('keeps selection, argument, and behavior metadata in their contract layers', () => {
@@ -223,6 +235,7 @@ describe('MCP v2 tool runtime', () => {
     expect(fullInstructions).toContain('solo_playtest');
     expect(fullInstructions).toContain('preview');
     expect(fullInstructions).toContain('robloxstudio://tool-guides');
+    expect(fullInstructions).toContain('selection action=view before capture_screenshot');
     expect(fullInstructions).not.toContain('—');
 
     const inspectorDefinitions = getReadOnlyTools();
@@ -233,6 +246,8 @@ describe('MCP v2 tool runtime', () => {
         expect(inspectorInstructions).not.toContain(definition.name);
       }
     }
+    expect(inspectorNames.has('selection')).toBe(true);
+    expect(inspectorInstructions).toContain('selection action=view before capture_screenshot');
     expect(inspectorInstructions).toContain('get_connected_instances');
     expect(inspectorInstructions).toContain('get_roblox_docs');
     expect(inspectorInstructions).toContain('robloxstudio://tool-guides');

--- a/packages/core/src/__tests__/selection.test.ts
+++ b/packages/core/src/__tests__/selection.test.ts
@@ -1,0 +1,80 @@
+import { BridgeService } from '../bridge-service.js';
+import { RobloxStudioTools } from '../tools/index.js';
+import { StudioHttpClient } from '../tools/studio-client.js';
+
+function registerRole(bridge: BridgeService, pluginSessionId: string, role: string, isRunning: boolean) {
+  const result = bridge.registerInstance({
+    pluginSessionId,
+    instanceId: 'place:test',
+    role,
+    placeId: 0,
+    placeName: 'TestPlace',
+    dataModelName: 'TestPlace',
+    isRunning,
+  });
+  if (!result.ok) throw new Error(`registerInstance failed: ${result.error.code}`);
+}
+
+describe('selection lifecycle tool', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('routes get and set to edit while view follows the screenshot viewport', async () => {
+    const bridge = new BridgeService();
+    registerRole(bridge, 'edit-session', 'edit', false);
+    registerRole(bridge, 'client-session', 'client-1', true);
+
+    const request = jest.spyOn(StudioHttpClient.prototype, 'request')
+      .mockResolvedValue({ success: true });
+    const tools = new RobloxStudioTools(bridge);
+
+    await tools.selection('get', {}, 'place:test');
+    expect(request).toHaveBeenLastCalledWith(
+      '/api/get-selection',
+      {},
+      'place:test',
+      'edit',
+      undefined,
+    );
+
+    await tools.selection('set', { paths: [], mode: 'set' }, 'place:test');
+    expect(request).toHaveBeenLastCalledWith(
+      '/api/set-selection',
+      { paths: [], mode: 'set' },
+      'place:test',
+      'edit',
+      undefined,
+    );
+
+    await tools.selection('view', {
+      path: 'game.Workspace.Subject',
+      padding: 1.25,
+    }, 'place:test');
+    expect(request).toHaveBeenLastCalledWith(
+      '/api/focus-viewport',
+      {
+        path: 'game.Workspace.Subject',
+        from: undefined,
+        padding: 1.25,
+        angleY: undefined,
+      },
+      'place:test',
+      'client-1',
+      undefined,
+    );
+  });
+
+  test('rejects invalid lifecycle arguments before dispatch', async () => {
+    const tools = new RobloxStudioTools(new BridgeService());
+
+    await expect(tools.selection('set', { paths: [''] }, 'place:test'))
+      .rejects.toThrow('non-empty instance paths');
+    await expect(tools.selection('view', { path: 'game.Workspace.Subject', padding: 0 }, 'place:test'))
+      .rejects.toThrow('greater than 0');
+    await expect(tools.selection('view', { path: 'game.Workspace.Subject', angleY: 90 }, 'place:test'))
+      .rejects.toThrow('between -89 and 89');
+    await expect(tools.selection('unknown', {}, 'place:test'))
+      .rejects.toThrow('action=get|set|view');
+  });
+});

--- a/packages/core/src/__tests__/smoke.test.ts
+++ b/packages/core/src/__tests__/smoke.test.ts
@@ -2277,7 +2277,7 @@ describe('Smoke', () => {
     })).toBe(true);
   });
 
-  test('client broker forwards script profiler captures to client peers', () => {
+  test('client broker forwards client-only viewport and profiler operations', () => {
     const cwd = process.cwd();
     const repoRoot = fs.existsSync(path.join(cwd, 'studio-plugin')) ? cwd : path.resolve(cwd, '../..');
     const source = fs.readFileSync(path.join(repoRoot, 'studio-plugin/src/modules/ClientBroker.ts'), 'utf8');
@@ -2285,6 +2285,8 @@ describe('Smoke', () => {
     expect(source).toContain('payload.endpoint === "/api/capture-script-profiler"');
     expect(source).toContain('"/api/capture-micro-profiler"');
     expect(source).toContain('payload.endpoint === "/api/capture-micro-profiler"');
+    expect(source).toContain('\t"/api/focus-viewport",');
+    expect(source).toContain('payload.endpoint === "/api/focus-viewport"');
   });
 
   test('breakpoints decorates response with resolved target role', async () => {

--- a/packages/core/src/__tests__/tool-schema.test.ts
+++ b/packages/core/src/__tests__/tool-schema.test.ts
@@ -75,15 +75,48 @@ describe('Tool schema compatibility', () => {
     expect(tool).toBeDefined();
     expect(tool!.category).toBe('read');
     expect(getReadOnlyTools()).toContain(tool);
+    expect(tool!.description).toBe('Use to get, set, or frame selection.');
 
     const schema = tool!.inputSchema as {
-      properties?: Record<string, { enum?: string[]; default?: unknown }>;
+      properties?: Record<string, {
+        description?: string;
+        enum?: string[];
+        default?: unknown;
+        items?: { minLength?: number };
+        minLength?: number;
+        exclusiveMinimum?: number;
+        minimum?: number;
+        maximum?: number;
+      }>;
       required?: string[];
     };
     const props = schema.properties ?? {};
     expect(schema.required).toEqual(['action']);
     expect(props.action.enum).toEqual(['get', 'set', 'view']);
     expect(props.mode).toMatchObject({ enum: ['set', 'add', 'remove'], default: 'set' });
+    expect(props.action.description).toBe('View frames the target.');
+    expect(props.paths).toMatchObject({
+      description: 'Set needs paths; empty clears in set mode.',
+      items: { minLength: 1 },
+    });
+    expect(props.mode.description).toBe('How set applies paths.');
+    expect(props.path).toMatchObject({
+      description: 'View needs a BasePart or Model path.',
+      minLength: 1,
+    });
+    expect(props.from.description).toBe('View azimuth: 0 +X, 90 +Z.');
+    expect(props.padding).toMatchObject({
+      description: 'View distance scale.',
+      default: 1,
+      exclusiveMinimum: 0,
+      maximum: 10,
+    });
+    expect(props.angleY).toMatchObject({
+      description: 'View elevation in degrees.',
+      minimum: -89,
+      maximum: 89,
+    });
+    expect(props.instance_id.description).toBe('Connected place ID if multiple are open.');
     expect(Object.keys(props).sort()).toEqual([
       'action',
       'angleY',

--- a/packages/core/src/__tests__/tool-schema.test.ts
+++ b/packages/core/src/__tests__/tool-schema.test.ts
@@ -1,4 +1,4 @@
-import { TOOL_DEFINITIONS } from '../tools/definitions.js';
+import { getReadOnlyTools, TOOL_DEFINITIONS } from '../tools/definitions.js';
 import { TOOL_HANDLERS } from '../http-server.js';
 import { RobloxStudioTools } from '../tools/index.js';
 import { BridgeService } from '../bridge-service.js';
@@ -68,6 +68,40 @@ describe('Tool schema compatibility', () => {
       expect(activeNames.has(name)).toBe(false);
       expect(TOOL_HANDLERS[name]).toBeUndefined();
     }
+  });
+
+  test('selection exposes one get/set/view lifecycle', () => {
+    const tool = TOOL_DEFINITIONS.find(candidate => candidate.name === 'selection');
+    expect(tool).toBeDefined();
+    expect(tool!.category).toBe('read');
+    expect(getReadOnlyTools()).toContain(tool);
+
+    const schema = tool!.inputSchema as {
+      properties?: Record<string, { enum?: string[]; default?: unknown }>;
+      required?: string[];
+    };
+    const props = schema.properties ?? {};
+    expect(schema.required).toEqual(['action']);
+    expect(props.action.enum).toEqual(['get', 'set', 'view']);
+    expect(props.mode).toMatchObject({ enum: ['set', 'add', 'remove'], default: 'set' });
+    expect(Object.keys(props).sort()).toEqual([
+      'action',
+      'angleY',
+      'from',
+      'instance_id',
+      'mode',
+      'padding',
+      'path',
+      'paths',
+    ]);
+
+    for (const removed of ['get_selection', 'set_selection', 'focus_viewport']) {
+      expect(TOOL_DEFINITIONS.some(candidate => candidate.name === removed)).toBe(false);
+      expect(TOOL_HANDLERS[removed]).toBeUndefined();
+    }
+    expect(TOOL_HANDLERS.selection).toBeDefined();
+    expect(TOOL_GUIDE_MARKDOWN).toContain('## Selection and viewport');
+    expect(TOOL_GUIDE_MARKDOWN).toContain('An empty paths array in set mode clears it');
   });
 
   test('grep_scripts exposes one explicit pattern-mode switch', () => {
@@ -188,9 +222,7 @@ describe('Tool schema compatibility', () => {
       insert_script_lines: 'insertScriptLines',
       delete_script_lines: 'deleteScriptLines',
       get_attributes: 'getAttributes',
-      get_selection: 'getSelection',
-      set_selection: 'setSelection',
-      focus_viewport: 'focusViewport',
+      selection: 'selection',
       execute_luau: 'executeLuau',
       eval_server_runtime: 'evalServerRuntime',
       eval_client_runtime: 'evalClientRuntime',

--- a/packages/core/src/__tests__/tool-schema.test.ts
+++ b/packages/core/src/__tests__/tool-schema.test.ts
@@ -189,6 +189,8 @@ describe('Tool schema compatibility', () => {
       delete_script_lines: 'deleteScriptLines',
       get_attributes: 'getAttributes',
       get_selection: 'getSelection',
+      set_selection: 'setSelection',
+      focus_viewport: 'focusViewport',
       execute_luau: 'executeLuau',
       eval_server_runtime: 'evalServerRuntime',
       eval_client_runtime: 'evalClientRuntime',

--- a/packages/core/src/http-server.ts
+++ b/packages/core/src/http-server.ts
@@ -112,6 +112,8 @@ export const TOOL_HANDLERS: Record<string, ToolHandler> = {
   },
   get_attributes: (tools, body) => tools.getAttributes(body.instancePath, body.instance_id),
   get_selection: (tools, body) => tools.getSelection(body.instance_id),
+  set_selection: (tools, body) => tools.setSelection(body.paths, body.mode, body.instance_id),
+  focus_viewport: (tools, body) => tools.focusViewport(body.path, body.from, body.padding, body.angleY, body.instance_id),
   execute_luau: (tools, body) => tools.executeLuau(body.code, body.target, body.instance_id),
   eval_server_runtime: (tools, body) => tools.evalServerRuntime(body.code, body.instance_id),
   eval_client_runtime: (tools, body) => tools.evalClientRuntime(body.code, body.target, body.instance_id),

--- a/packages/core/src/http-server.ts
+++ b/packages/core/src/http-server.ts
@@ -111,9 +111,7 @@ export const TOOL_HANDLERS: Record<string, ToolHandler> = {
     return tools.deleteScriptLines(body.instancePath, startLine, endLine, body.instance_id);
   },
   get_attributes: (tools, body) => tools.getAttributes(body.instancePath, body.instance_id),
-  get_selection: (tools, body) => tools.getSelection(body.instance_id),
-  set_selection: (tools, body) => tools.setSelection(body.paths, body.mode, body.instance_id),
-  focus_viewport: (tools, body) => tools.focusViewport(body.path, body.from, body.padding, body.angleY, body.instance_id),
+  selection: (tools, body) => tools.selection(body.action, body, body.instance_id),
   execute_luau: (tools, body) => tools.executeLuau(body.code, body.target, body.instance_id),
   eval_server_runtime: (tools, body) => tools.evalServerRuntime(body.code, body.instance_id),
   eval_client_runtime: (tools, body) => tools.evalClientRuntime(body.code, body.target, body.instance_id),

--- a/packages/core/src/mcp-compat.ts
+++ b/packages/core/src/mcp-compat.ts
@@ -17,7 +17,6 @@ Tool descriptions explain selection. Input schemas explain arguments. This guide
 - Use canonical DataModel paths returned by the tools. Paths usually start with game.
 - Call get_connected_instances when more than one place may be connected. Pass the chosen row's id as instance_id on later calls.
 - Use get_place_info for the active place identity and settings.
-- Use get_selection only when the user's current Studio selection should set the scope.
 
 ## Discovery and edit work
 
@@ -25,6 +24,13 @@ Tool descriptions explain selection. Input schemas explain arguments. This guide
 - Use get_instance_properties and get_attributes after locating an instance.
 - Use execute_luau for custom traversal, bulk edits, and work that would otherwise need many tool calls. It runs through the Studio plugin context.
 - Use set_properties when several known properties on one instance can be updated in one request.
+
+## Selection and viewport
+
+- Use selection with action=get when the user's Studio selection should define the scope.
+- Use action=set with instance paths to replace, add to, or remove from the selection. An empty paths array in set mode clears it.
+- Use action=view with a BasePart or Model path to frame it. The current viewing direction is preserved unless from or angleY overrides it. padding below 1 crops closer and above 1 pulls back.
+- For visual proof, change the instance, frame it with selection, then call capture_screenshot.
 
 ## Script changes
 

--- a/packages/core/src/mcp-runtime.ts
+++ b/packages/core/src/mcp-runtime.ts
@@ -63,6 +63,7 @@ const SIDE_EFFECTING_READ_TOOLS = new Set([
   'capture_micro_profiler',
   'capture_script_profiler',
   'export_rbxm',
+  'selection',
 ]);
 const NON_DESTRUCTIVE_SIDE_EFFECT_TOOLS = new Set([
   'capture_device_matrix',
@@ -71,6 +72,7 @@ const NON_DESTRUCTIVE_SIDE_EFFECT_TOOLS = new Set([
   'insert_asset',
   'insert_script_lines',
   'upload_asset',
+  'selection',
 ]);
 const IDEMPOTENT_WRITE_TOOLS = new Set([
   'capture_device_matrix',
@@ -80,6 +82,7 @@ const IDEMPOTENT_WRITE_TOOLS = new Set([
   'set_network_profile',
   'set_properties',
   'set_script_source',
+  'selection',
 ]);
 const OPEN_WORLD_TOOLS = new Set([
   'eval_client_runtime',
@@ -269,6 +272,11 @@ export function serverInstructions(definitions: readonly ToolDefinition[]): stri
   }
   if (has('capture_screenshot', 'simulate_mouse_input')) {
     instructions.push('Capture a screenshot before sending mouse input so its pixel coordinates match the viewport.');
+  }
+  if (has('selection', 'capture_screenshot')) {
+    instructions.push(
+      'Use selection action=view before capture_screenshot when the viewport must frame a specific instance.',
+    );
   }
   if (has('get_roblox_docs')) {
     instructions.push('Use get_roblox_docs instead of guessing unfamiliar engine or Luau APIs.');

--- a/packages/core/src/tools/definitions.ts
+++ b/packages/core/src/tools/definitions.ts
@@ -283,81 +283,63 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
 
   // === Selection ===
   {
-    name: 'get_selection',
+    name: 'selection',
     category: 'read',
-    description: 'Use when the current Studio selection should define the objects to work on.',
+    description: 'Use to read, change, or frame the Studio selection.',
     inputSchema: {
       type: 'object',
       properties: {
-        instance_id: {
+        action: {
           type: 'string',
-          description: 'Connected place ID; required with multiple places.'
-        }
-      }
-    }
-  },
-  {
-    name: 'set_selection',
-    category: 'write',
-    description: 'Set which objects are highlighted in the Studio editor. Select what you just built or changed: it shows the user the result, and puts the instance under Studio\'s own move and scale handles. Pairs with capture_screenshot — select, then screenshot, so the shot shows what changed. mode="set" replaces the selection (default), "add" extends it, "remove" shrinks it; an empty paths array with mode="set" clears the selection.',
-    inputSchema: {
-      type: 'object',
-      properties: {
+          enum: ['get', 'set', 'view'],
+          description: 'Lifecycle action.'
+        },
         paths: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'Instance paths to select, e.g. ["game.Workspace.House.Door"]. Empty array + mode="set" clears.'
+          items: { type: 'string', minLength: 1 },
+          description: 'Set paths; empty clears.'
         },
         mode: {
           type: 'string',
           enum: ['set', 'add', 'remove'],
-          description: '"set" replaces the whole selection (default), "add" extends it, "remove" deselects just these.'
+          default: 'set',
+          description: 'Update mode.'
         },
-        instance_id: {
-          type: 'string',
-          description: 'Which connected Studio place to target. Required when multiple places are connected; omit when one. Use get_connected_instances to list available IDs.'
-        }
-      },
-      required: ['paths']
-    }
-  },
-  {
-    name: 'focus_viewport',
-    category: 'write',
-    description: 'Aim the Studio camera at an instance and frame it so the whole thing is on screen. This is what makes capture_screenshot worth having: a picture of wherever the camera happened to be answers nothing, while a picture of the thing you just built answers "does it look right". Workflow: build or change something, focus_viewport it, capture_screenshot. The framing distance is computed from the instance\'s bounding size and the camera\'s field of view, so a doorway and a whole map both fill a similar share of the frame. Use from to pick the viewing direction (a compass angle in degrees: 0 looks from +X toward origin, 90 from +Z), padding to zoom tighter (<1) or wider (>1). Works in Edit mode and during playtests on the running client viewport.',
-    inputSchema: {
-      type: 'object',
-      properties: {
         path: {
           type: 'string',
-          description: 'The instance to look at: a part, model, or folder containing them.'
+          minLength: 1,
+          description: 'BasePart or Model path for view.'
         },
         from: {
           type: 'number',
-          description: 'Optional compass angle in degrees for where to view from. Omit to keep a sensible default angle.'
+          description: 'Compass degrees: 0 from +X, 90 from +Z.'
         },
         padding: {
           type: 'number',
-          description: 'Optional framing tightness: 1 fills the frame (default), <1 crops closer, >1 pulls back.'
+          exclusiveMinimum: 0,
+          maximum: 10,
+          default: 1,
+          description: 'Distance scale.'
         },
         angleY: {
           type: 'number',
-          description: 'Optional elevation in degrees above horizontal (default ~20, clamped to avoid gimbal flip at the poles).'
+          minimum: -89,
+          maximum: 89,
+          description: 'Elevation degrees.'
         },
         instance_id: {
           type: 'string',
-          description: 'Which connected Studio place to target. Required when multiple places are connected; omit when one. Use get_connected_instances to list available IDs.'
+          description: 'Place ID; required if ambiguous.'
         }
       },
-      required: ['path']
+      required: ['action']
     }
   },
 
-  // === Luau Execution ===
   {
     name: 'execute_luau',
     category: 'write',
-    description: 'Use for custom edit work or plugin-context access to a live server or client.',
+    description: 'Use for custom Studio traversal, edits, or peer execution.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -380,7 +362,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'eval_server_runtime',
     category: 'write',
-    description: 'Use when Luau must run in the live server Script VM and share the game\'s require cache.',
+    description: 'Use to run Luau in the live server VM with its require cache.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -399,7 +381,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'eval_client_runtime',
     category: 'write',
-    description: 'Use when Luau must run in a live client LocalScript VM and share the game\'s require cache.',
+    description: 'Use to run Luau in a live client VM with its require cache.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -478,7 +460,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'manage_instance',
     category: 'write',
-    description: 'Use to launch, inspect, authorize, or close Studio processes and list place revisions.',
+    description: 'Use to manage Studio processes or list place revisions.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -603,7 +585,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'set_network_profile',
     category: 'write',
-    description: 'Use to apply simulated latency, jitter, or packet loss to playtest clients.',
+    description: 'Use to simulate client latency, jitter, or packet loss.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -666,7 +648,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'get_simulation_state',
     category: 'read',
-    description: 'Use to inspect network and device simulator state before or after simulation tests.',
+    description: 'Use to inspect current network and device simulation.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -689,7 +671,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'reset_simulation_state',
     category: 'write',
-    description: 'Use to clear network and device simulator settings between simulation tests.',
+    description: 'Use to clear network and device simulation state.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -715,7 +697,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'get_device_simulator_state',
     category: 'read',
-    description: 'Use to inspect active device simulation or list built-in device presets.',
+    description: 'Use to inspect device simulation or list device presets.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -741,7 +723,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'set_device_simulator',
     category: 'write',
-    description: 'Use to start, change, or stop device simulation in edit mode or on playtest clients.',
+    description: 'Use to manage device simulation in edit or a playtest client.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -878,7 +860,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'multiplayer_playtest',
     category: 'write',
-    description: 'Use to run or inspect a StudioTestService playtest with multiple clients.',
+    description: 'Use to run or inspect a multi-client Studio playtest.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1008,7 +990,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'capture_micro_profiler',
     category: 'read',
-    description: 'Use to attribute frame time across engine and game work on a running server or client.',
+    description: 'Use to profile engine and game frame time on a live peer.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1135,7 +1117,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'breakpoints',
     category: 'write',
-    description: 'Use when Studio breakpoints or logpoints are needed to trace script execution.',
+    description: 'Use to trace script execution with breakpoints or logpoints.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1236,7 +1218,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'get_asset_details',
     category: 'read',
-    description: 'Use to inspect full catalog metadata for one shortlisted Creator Store asset.',
+    description: 'Use to inspect a shortlisted Creator Store asset.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1303,7 +1285,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'generate_model',
     category: 'write',
-    description: 'Use to generate and stage a Roblox model from text or an image reference.',
+    description: 'Use to stage a Roblox model from text or an image.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1455,7 +1437,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'capture_screenshot',
     category: 'read',
-    description: 'Use when you need the current Studio viewport as an image or input coordinate map.',
+    description: 'Use to capture the Studio viewport or map input coordinates.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1554,7 +1536,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'get_memory_breakdown',
     category: 'read',
-    description: 'Use to compare Roblox memory categories across edit, server, or client peers.',
+    description: 'Use to compare memory categories across Studio peers.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1577,7 +1559,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'get_scene_analysis',
     category: 'read',
-    description: 'Use to attribute scene cost to instances, scripts, triangles, animation, or audio.',
+    description: 'Use to attribute scene cost across instances and content.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1681,7 +1663,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'find_and_replace_in_scripts',
     category: 'write',
-    description: 'Use to preview or apply the same text replacement across multiple scripts.',
+    description: 'Use to preview or apply one replacement across scripts.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1731,7 +1713,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'get_roblox_skills',
     category: 'read',
-    description: 'Use to list or read Roblox-authored Studio Assistant skills on demand.',
+    description: 'Use to read installed Roblox Studio Assistant skills.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1753,7 +1735,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'get_roblox_docs',
     category: 'read',
-    description: 'Use to look up official Roblox engine or Luau reference documentation.',
+    description: 'Use to read official Roblox engine or Luau references.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/packages/core/src/tools/definitions.ts
+++ b/packages/core/src/tools/definitions.ts
@@ -296,6 +296,62 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       }
     }
   },
+  {
+    name: 'set_selection',
+    category: 'write',
+    description: 'Set which objects are highlighted in the Studio editor. Select what you just built or changed: it shows the user the result, and puts the instance under Studio\'s own move and scale handles. Pairs with capture_screenshot — select, then screenshot, so the shot shows what changed. mode="set" replaces the selection (default), "add" extends it, "remove" shrinks it; an empty paths array with mode="set" clears the selection.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        paths: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Instance paths to select, e.g. ["game.Workspace.House.Door"]. Empty array + mode="set" clears.'
+        },
+        mode: {
+          type: 'string',
+          enum: ['set', 'add', 'remove'],
+          description: '"set" replaces the whole selection (default), "add" extends it, "remove" deselects just these.'
+        },
+        instance_id: {
+          type: 'string',
+          description: 'Which connected Studio place to target. Required when multiple places are connected; omit when one. Use get_connected_instances to list available IDs.'
+        }
+      },
+      required: ['paths']
+    }
+  },
+  {
+    name: 'focus_viewport',
+    category: 'write',
+    description: 'Aim the Studio camera at an instance and frame it so the whole thing is on screen. This is what makes capture_screenshot worth having: a picture of wherever the camera happened to be answers nothing, while a picture of the thing you just built answers "does it look right". Workflow: build or change something, focus_viewport it, capture_screenshot. The framing distance is computed from the instance\'s bounding size and the camera\'s field of view, so a doorway and a whole map both fill a similar share of the frame. Use from to pick the viewing direction (a compass angle in degrees: 0 looks from +X toward origin, 90 from +Z), padding to zoom tighter (<1) or wider (>1). Works in Edit mode and during playtests on the running client viewport.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'The instance to look at: a part, model, or folder containing them.'
+        },
+        from: {
+          type: 'number',
+          description: 'Optional compass angle in degrees for where to view from. Omit to keep a sensible default angle.'
+        },
+        padding: {
+          type: 'number',
+          description: 'Optional framing tightness: 1 fills the frame (default), <1 crops closer, >1 pulls back.'
+        },
+        angleY: {
+          type: 'number',
+          description: 'Optional elevation in degrees above horizontal (default ~20, clamped to avoid gimbal flip at the poles).'
+        },
+        instance_id: {
+          type: 'string',
+          description: 'Which connected Studio place to target. Required when multiple places are connected; omit when one. Use get_connected_instances to list available IDs.'
+        }
+      },
+      required: ['path']
+    }
+  },
 
   // === Luau Execution ===
   {

--- a/packages/core/src/tools/definitions.ts
+++ b/packages/core/src/tools/definitions.ts
@@ -285,51 +285,51 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'selection',
     category: 'read',
-    description: 'Use to read, change, or frame the Studio selection.',
+    description: 'Use to get, set, or frame selection.',
     inputSchema: {
       type: 'object',
       properties: {
         action: {
           type: 'string',
           enum: ['get', 'set', 'view'],
-          description: 'Lifecycle action.'
+          description: 'View frames the target.'
         },
         paths: {
           type: 'array',
           items: { type: 'string', minLength: 1 },
-          description: 'Set paths; empty clears.'
+          description: 'Set needs paths; empty clears in set mode.'
         },
         mode: {
           type: 'string',
           enum: ['set', 'add', 'remove'],
           default: 'set',
-          description: 'Update mode.'
+          description: 'How set applies paths.'
         },
         path: {
           type: 'string',
           minLength: 1,
-          description: 'BasePart or Model path for view.'
+          description: 'View needs a BasePart or Model path.'
         },
         from: {
           type: 'number',
-          description: 'Compass degrees: 0 from +X, 90 from +Z.'
+          description: 'View azimuth: 0 +X, 90 +Z.'
         },
         padding: {
           type: 'number',
           exclusiveMinimum: 0,
           maximum: 10,
           default: 1,
-          description: 'Distance scale.'
+          description: 'View distance scale.'
         },
         angleY: {
           type: 'number',
           minimum: -89,
           maximum: 89,
-          description: 'Elevation degrees.'
+          description: 'View elevation in degrees.'
         },
         instance_id: {
           type: 'string',
-          description: 'Place ID; required if ambiguous.'
+          description: 'Connected place ID if multiple are open.'
         }
       },
       required: ['action']

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -1742,8 +1742,41 @@ export class RobloxStudioTools {
     };
   }
 
+  async selection(
+    action: string,
+    opts: {
+      paths?: unknown;
+      mode?: string;
+      path?: string;
+      from?: number;
+      padding?: number;
+      angleY?: number;
+    } = {},
+    instance_id?: string,
+  ) {
+    if (action !== 'get' && action !== 'set' && action !== 'view') {
+      throw new Error('selection requires action=get|set|view');
+    }
+
+    if (action === 'get') {
+      return this.getSelection(instance_id);
+    }
+
+    if (action === 'set') {
+      if (!Array.isArray(opts.paths)) {
+        throw new Error('selection action=set requires a paths array; empty clears');
+      }
+      return this.setSelection(opts.paths, opts.mode, instance_id);
+    }
+
+    if (!opts.path) {
+      throw new Error('selection action=view requires path');
+    }
+    return this.focusViewport(opts.path, opts.from, opts.padding, opts.angleY, instance_id);
+  }
+
   async getSelection(instance_id?: string) {
-    const response = await this._callSingle('/api/get-selection', {}, undefined, instance_id);
+    const response = await this._callSingle('/api/get-selection', {}, 'edit', instance_id);
     return {
       content: [
         {
@@ -1755,14 +1788,19 @@ export class RobloxStudioTools {
   }
 
   async setSelection(paths: string[], mode: string | undefined, instance_id?: string) {
-    if (!Array.isArray(paths)) {
-      throw new Error('set_selection requires paths (array of instance paths; empty array clears the selection)');
+    if (!Array.isArray(paths) || paths.some(path => typeof path !== 'string' || path.length === 0)) {
+      throw new Error('selection paths must contain only non-empty instance paths');
     }
-    const selectionMode = mode || 'set';
+    const selectionMode = mode ?? 'set';
     if (!['set', 'add', 'remove'].includes(selectionMode)) {
-      throw new Error(`set_selection mode must be "set", "add" or "remove" (got: ${selectionMode})`);
+      throw new Error(`selection mode must be "set", "add" or "remove" (got: ${selectionMode})`);
     }
-    const response = await this._callSingle('/api/set-selection', { paths, mode: selectionMode }, undefined, instance_id);
+    const response = await this._callSingle(
+      '/api/set-selection',
+      { paths, mode: selectionMode },
+      'edit',
+      instance_id,
+    );
     return {
       content: [
         {
@@ -1773,16 +1811,30 @@ export class RobloxStudioTools {
     };
   }
 
-  async focusViewport(instancePath: string, from?: unknown, padding?: number, angleY?: number, instance_id?: string) {
+  async focusViewport(
+    instancePath: string,
+    from?: number,
+    padding?: number,
+    angleY?: number,
+    instance_id?: string,
+  ) {
     if (!instancePath) {
-      throw new Error('focus_viewport requires path (the instance to frame)');
+      throw new Error('selection action=view requires path');
     }
+    if (padding !== undefined && (padding <= 0 || padding > 10)) {
+      throw new Error('selection padding must be greater than 0 and at most 10');
+    }
+    if (angleY !== undefined && (angleY < -89 || angleY > 89)) {
+      throw new Error('selection angleY must be between -89 and 89');
+    }
+
+    const { instanceId, clientRole } = this._resolveRuntime(instance_id);
     const response = await this._callSingle('/api/focus-viewport', {
       path: instancePath,
       from,
       padding,
       angleY,
-    }, undefined, instance_id);
+    }, clientRole ?? 'edit', instanceId);
     return {
       content: [
         {

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -1754,6 +1754,45 @@ export class RobloxStudioTools {
     };
   }
 
+  async setSelection(paths: string[], mode: string | undefined, instance_id?: string) {
+    if (!Array.isArray(paths)) {
+      throw new Error('set_selection requires paths (array of instance paths; empty array clears the selection)');
+    }
+    const selectionMode = mode || 'set';
+    if (!['set', 'add', 'remove'].includes(selectionMode)) {
+      throw new Error(`set_selection mode must be "set", "add" or "remove" (got: ${selectionMode})`);
+    }
+    const response = await this._callSingle('/api/set-selection', { paths, mode: selectionMode }, undefined, instance_id);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(response)
+        }
+      ]
+    };
+  }
+
+  async focusViewport(instancePath: string, from?: unknown, padding?: number, angleY?: number, instance_id?: string) {
+    if (!instancePath) {
+      throw new Error('focus_viewport requires path (the instance to frame)');
+    }
+    const response = await this._callSingle('/api/focus-viewport', {
+      path: instancePath,
+      from,
+      padding,
+      angleY,
+    }, undefined, instance_id);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(response)
+        }
+      ]
+    };
+  }
+
   async executeLuau(code: string, target?: string, instance_id?: string) {
     if (!code) {
       throw new Error('Code is required for execute_luau');

--- a/studio-plugin/src/modules/ClientBroker.ts
+++ b/studio-plugin/src/modules/ClientBroker.ts
@@ -4,6 +4,7 @@ import MemoryHandlers from "./handlers/MemoryHandlers";
 import SceneAnalysisHandlers from "./handlers/SceneAnalysisHandlers";
 import CaptureHandlers from "./handlers/CaptureHandlers";
 import InputHandlers from "./handlers/InputHandlers";
+import MetadataHandlers from "./handlers/MetadataHandlers";
 import EvalRuntimeHandlers from "./handlers/EvalRuntimeHandlers";
 import BreakpointHandlers from "./handlers/BreakpointHandlers";
 import ScriptProfilerHandlers from "./handlers/ScriptProfilerHandlers";
@@ -109,6 +110,8 @@ const CLIENT_BROKER_ALLOWED_ENDPOINTS = new Set<string>([
 	// pipeline, so it must execute in the client peer's VM.
 	"/api/simulate-mouse-input",
 	"/api/simulate-keyboard-input",
+	// Viewport framing must target the same live client captured by screenshots.
+	"/api/focus-viewport",
 ]);
 
 interface ReadyResponseBody {
@@ -295,6 +298,9 @@ function setupClientBroker() {
 		}
 		if (payload && payload.endpoint === "/api/simulate-keyboard-input") {
 			return InputHandlers.simulateKeyboardInput(payload.data ?? {});
+		}
+		if (payload && payload.endpoint === "/api/focus-viewport") {
+			return MetadataHandlers.focusViewport(payload.data ?? {});
 		}
 		if (payload && payload.endpoint === "/api/execute-luau") {
 			return handleExecuteLuau(payload.data);

--- a/studio-plugin/src/modules/Communication.ts
+++ b/studio-plugin/src/modules/Communication.ts
@@ -116,10 +116,12 @@ const routeMap: Record<string, Handler> = {
 	"/api/insert-script-lines": ScriptHandlers.insertScriptLines,
 	"/api/delete-script-lines": ScriptHandlers.deleteScriptLines,
 
-    "/api/get-attributes": MetadataHandlers.getAttributes,
-    "/api/get-selection": MetadataHandlers.getSelection,
-    "/api/execute-luau": MetadataHandlers.executeLuau,
-    "/api/eval-runtime": EvalRuntimeHandlers.evalRuntime,
+	"/api/get-attributes": MetadataHandlers.getAttributes,
+	"/api/get-selection": MetadataHandlers.getSelection,
+	"/api/set-selection": MetadataHandlers.setSelection,
+	"/api/focus-viewport": MetadataHandlers.focusViewport,
+	"/api/execute-luau": MetadataHandlers.executeLuau,
+	"/api/eval-runtime": EvalRuntimeHandlers.evalRuntime,
 
 	"/api/start-playtest": TestHandlers.startPlaytest,
 	"/api/stop-playtest": TestHandlers.stopPlaytest,

--- a/studio-plugin/src/modules/handlers/MetadataHandlers.ts
+++ b/studio-plugin/src/modules/handlers/MetadataHandlers.ts
@@ -85,7 +85,7 @@ function getSelection(_requestData: Record<string, unknown>) {
 function setSelection(requestData: Record<string, unknown>) {
 	const rawPaths = requestData.paths;
 	if (!typeIs(rawPaths, "table")) {
-		return { error: "paths is required (array of instance paths; empty array clears the selection)" };
+		return { error: "paths is required (an empty array clears in set mode)" };
 	}
 
 	const mode = (requestData.mode as string) ?? "set";
@@ -93,19 +93,27 @@ function setSelection(requestData: Record<string, unknown>) {
 		return { error: `mode must be "set", "add" or "remove" (got: ${mode})` };
 	}
 
+	const paths = rawPaths as unknown[];
+	if (paths.size() === 0 && mode !== "set") {
+		return { error: `paths cannot be empty in ${mode} mode` };
+	}
+
 	const targets: Instance[] = [];
 	const missing: string[] = [];
-	for (const entry of rawPaths as unknown[]) {
-		const path = tostring(entry);
-		const instance = getInstanceByPath(path);
+	for (const entry of paths) {
+		if (!typeIs(entry, "string") || entry === "") {
+			return { error: "paths must contain non-empty instance path strings" };
+		}
+		const instance = getInstanceByPath(entry);
 		if (instance) {
 			targets.push(instance);
 		} else {
-			missing.push(path);
+			missing.push(entry);
 		}
 	}
 
-	if (targets.size() === 0) {
+	const clearsSelection = mode === "set" && paths.size() === 0;
+	if (targets.size() === 0 && !clearsSelection) {
 		return { error: "No matching instances found for any path", missingPaths: missing };
 	}
 
@@ -127,9 +135,11 @@ function setSelection(requestData: Record<string, unknown>) {
 		selected: targets.size(),
 		missingPaths: missing,
 		message:
-			mode === "remove"
-				? `Deselected ${targets.size()} object(s)`
-				: `${targets.size()} object(s) ${mode === "add" ? "added to" : "in"} the selection`,
+			clearsSelection
+				? "Selection cleared"
+				: mode === "remove"
+					? `Deselected ${targets.size()} object(s)`
+					: `${targets.size()} object(s) ${mode === "add" ? "added to" : "in"} the selection`,
 	};
 }
 
@@ -145,26 +155,30 @@ function focusViewport(requestData: Record<string, unknown>) {
 	if (!instance) return { error: `Instance not found: ${instancePath}` };
 
 	const workspace = game.GetService("Workspace");
-	// CurrentCamera is nil in rare windows (headless edit sessions, mid-swap);
-	// better a clear error than a nil deref inside the pcall.
 	const camera = workspace.CurrentCamera;
 	if (!camera) return { error: "Workspace.CurrentCamera is unavailable right now" };
 
 	const padding = tonumber(requestData.padding as number) ?? 1;
 	if (padding <= 0 || padding > 10) {
-		return { error: "padding must be between 0 (exclusive) and 10" };
+		return { error: "padding must be greater than 0 and at most 10" };
 	}
 
-	// Where we view from. Default elevation keeps most subjects readable
-	// (straight-on hides the top face); `from` picks the compass direction.
-	let angleY = tonumber(requestData.angleY as number) ?? 20;
-	if (angleY > 89) angleY = 89;
-	if (angleY < -89) angleY = -89;
-	const compassDeg = tonumber(requestData.from as number) ?? 215;
+	const compassOverride =
+		requestData.from === undefined ? undefined : tonumber(requestData.from as number);
+	if (requestData.from !== undefined && compassOverride === undefined) {
+		return { error: "from must be a compass angle in degrees" };
+	}
+
+	const elevationOverride =
+		requestData.angleY === undefined ? undefined : tonumber(requestData.angleY as number);
+	if (
+		requestData.angleY !== undefined &&
+		(elevationOverride === undefined || elevationOverride < -89 || elevationOverride > 89)
+	) {
+		return { error: "angleY must be between -89 and 89" };
+	}
 
 	const [ok, err] = pcall(() => {
-		// Only parts and models have a 3D extent; folders and scripts don't.
-		// Report that as a readable message instead of a raw API error.
 		let boundsCF: CFrame;
 		let boundsSize: Vector3;
 		if (instance.IsA("Model")) {
@@ -177,25 +191,40 @@ function focusViewport(requestData: Record<string, unknown>) {
 				`Cannot frame a ${instance.ClassName}: it has no 3D bounding box. Frame a part or model instead.`
 			);
 		}
-		const radius = math.max(boundsSize.X, math.max(boundsSize.Y, boundsSize.Z)) / 2;
 
-		// Half the vertical FOV plus half the horizontal FOV (via aspect ratio)
-		// must both cover the subject; solve for distance with a little margin.
-		const fovY = math.rad(camera.FieldOfView);
-		const viewport = camera.ViewportSize;
-		const fovX = 2 * math.atan(math.tan(fovY / 2) * (viewport.X / math.max(viewport.Y, 1)));
-		const fitDistance = radius / math.sin(math.min(fovY, fovX) / 2);
+		const center = boundsCF.Position;
+		let direction = camera.CFrame.LookVector.mul(-1);
 
-		const yaw = math.rad(compassDeg);
-		const pitch = math.rad(angleY);
-		const direction = new Vector3(math.cos(pitch) * math.cos(yaw), math.sin(pitch), math.cos(pitch) * math.sin(yaw));
-		const eye = boundsCF.Position.add(direction.Unit.mul(fitDistance * padding));
+		const currentHorizontal = new Vector3(direction.X, 0, direction.Z);
+		let horizontalDirection =
+			currentHorizontal.Magnitude < 0.001 ? new Vector3(1, 0, 0) : currentHorizontal.Unit;
+		if (compassOverride !== undefined) {
+			const yaw = math.rad(compassOverride);
+			horizontalDirection = new Vector3(math.cos(yaw), 0, math.sin(yaw));
+		}
 
-		camera.CFrame = CFrame.lookAt(eye, boundsCF.Position);
+		let vertical = direction.Y;
+		let horizontalMagnitude = math.sqrt(math.max(0, 1 - vertical * vertical));
+		if (elevationOverride !== undefined) {
+			const pitch = math.rad(elevationOverride);
+			vertical = math.sin(pitch);
+			horizontalMagnitude = math.cos(pitch);
+		}
+		direction = horizontalDirection
+			.mul(horizontalMagnitude)
+			.add(new Vector3(0, vertical, 0))
+			.Unit;
 
-		// In edit mode the camera can be re-owned by Studio's camera scripts on
-		// the next input; setting CameraType pins our shot until the user moves.
 		camera.CameraType = Enum.CameraType.Scriptable;
+		camera.CFrame = CFrame.lookAt(center.add(direction.mul(math.max(boundsSize.Magnitude, 1))), center);
+		camera.Focus = new CFrame(center);
+		camera.ZoomToExtents(boundsCF, boundsSize);
+
+		if (padding !== 1) {
+			const fittedOffset = camera.CFrame.Position.sub(center);
+			camera.CFrame = CFrame.lookAt(center.add(fittedOffset.mul(padding)), center);
+		}
+		camera.Focus = new CFrame(center);
 	});
 
 	if (!ok) return { error: `focus failed: ${tostring(err)}` };
@@ -208,7 +237,6 @@ function focusViewport(requestData: Record<string, unknown>) {
 			Y: camera.CFrame.Position.Y,
 			Z: camera.CFrame.Position.Z,
 		},
-		message: "Camera framed on target. Take capture_screenshot now.",
 	};
 }
 

--- a/studio-plugin/src/modules/handlers/MetadataHandlers.ts
+++ b/studio-plugin/src/modules/handlers/MetadataHandlers.ts
@@ -79,6 +79,139 @@ function getSelection(_requestData: Record<string, unknown>) {
 	};
 }
 
+// The counterpart to getSelection: this sets it. Selecting what the agent just
+// built shows the user the result and puts the instance under Studio's own
+// move/scale handles, which is why it is a tool and not left to execute_luau.
+function setSelection(requestData: Record<string, unknown>) {
+	const rawPaths = requestData.paths;
+	if (!typeIs(rawPaths, "table")) {
+		return { error: "paths is required (array of instance paths; empty array clears the selection)" };
+	}
+
+	const mode = (requestData.mode as string) ?? "set";
+	if (mode !== "set" && mode !== "add" && mode !== "remove") {
+		return { error: `mode must be "set", "add" or "remove" (got: ${mode})` };
+	}
+
+	const targets: Instance[] = [];
+	const missing: string[] = [];
+	for (const entry of rawPaths as unknown[]) {
+		const path = tostring(entry);
+		const instance = getInstanceByPath(path);
+		if (instance) {
+			targets.push(instance);
+		} else {
+			missing.push(path);
+		}
+	}
+
+	if (targets.size() === 0) {
+		return { error: "No matching instances found for any path", missingPaths: missing };
+	}
+
+	const [ok, err] = pcall(() => {
+		if (mode === "add") {
+			Selection.Add(targets);
+		} else if (mode === "remove") {
+			Selection.Remove(targets);
+		} else {
+			Selection.Set(targets);
+		}
+	});
+
+	if (!ok) return { error: `Selection.${mode} failed: ${tostring(err)}` };
+
+	return {
+		success: true,
+		mode,
+		selected: targets.size(),
+		missingPaths: missing,
+		message:
+			mode === "remove"
+				? `Deselected ${targets.size()} object(s)`
+				: `${targets.size()} object(s) ${mode === "add" ? "added to" : "in"} the selection`,
+	};
+}
+
+// Aims the Studio camera at an instance and frames it from a sensible angle.
+// This completes the screenshot loop capture_screenshot documents: build,
+// focus, screenshot. Framing distance comes from the bounding box and the
+// camera's own field of view so any subject fills a similar share of frame.
+function focusViewport(requestData: Record<string, unknown>) {
+	const instancePath = requestData.path as string;
+	if (!instancePath) return { error: "path is required (the instance to frame)" };
+
+	const instance = getInstanceByPath(instancePath);
+	if (!instance) return { error: `Instance not found: ${instancePath}` };
+
+	const workspace = game.GetService("Workspace");
+	// CurrentCamera is nil in rare windows (headless edit sessions, mid-swap);
+	// better a clear error than a nil deref inside the pcall.
+	const camera = workspace.CurrentCamera;
+	if (!camera) return { error: "Workspace.CurrentCamera is unavailable right now" };
+
+	const padding = tonumber(requestData.padding as number) ?? 1;
+	if (padding <= 0 || padding > 10) {
+		return { error: "padding must be between 0 (exclusive) and 10" };
+	}
+
+	// Where we view from. Default elevation keeps most subjects readable
+	// (straight-on hides the top face); `from` picks the compass direction.
+	let angleY = tonumber(requestData.angleY as number) ?? 20;
+	if (angleY > 89) angleY = 89;
+	if (angleY < -89) angleY = -89;
+	const compassDeg = tonumber(requestData.from as number) ?? 215;
+
+	const [ok, err] = pcall(() => {
+		// Only parts and models have a 3D extent; folders and scripts don't.
+		// Report that as a readable message instead of a raw API error.
+		let boundsCF: CFrame;
+		let boundsSize: Vector3;
+		if (instance.IsA("Model")) {
+			[boundsCF, boundsSize] = instance.GetBoundingBox();
+		} else if (instance.IsA("BasePart")) {
+			boundsCF = instance.CFrame;
+			boundsSize = instance.Size;
+		} else {
+			return error(
+				`Cannot frame a ${instance.ClassName}: it has no 3D bounding box. Frame a part or model instead.`
+			);
+		}
+		const radius = math.max(boundsSize.X, math.max(boundsSize.Y, boundsSize.Z)) / 2;
+
+		// Half the vertical FOV plus half the horizontal FOV (via aspect ratio)
+		// must both cover the subject; solve for distance with a little margin.
+		const fovY = math.rad(camera.FieldOfView);
+		const viewport = camera.ViewportSize;
+		const fovX = 2 * math.atan(math.tan(fovY / 2) * (viewport.X / math.max(viewport.Y, 1)));
+		const fitDistance = radius / math.sin(math.min(fovY, fovX) / 2);
+
+		const yaw = math.rad(compassDeg);
+		const pitch = math.rad(angleY);
+		const direction = new Vector3(math.cos(pitch) * math.cos(yaw), math.sin(pitch), math.cos(pitch) * math.sin(yaw));
+		const eye = boundsCF.Position.add(direction.Unit.mul(fitDistance * padding));
+
+		camera.CFrame = CFrame.lookAt(eye, boundsCF.Position);
+
+		// In edit mode the camera can be re-owned by Studio's camera scripts on
+		// the next input; setting CameraType pins our shot until the user moves.
+		camera.CameraType = Enum.CameraType.Scriptable;
+	});
+
+	if (!ok) return { error: `focus failed: ${tostring(err)}` };
+
+	return {
+		success: true,
+		path: getInstancePath(instance),
+		cameraPosition: {
+			X: camera.CFrame.Position.X,
+			Y: camera.CFrame.Position.Y,
+			Z: camera.CFrame.Position.Z,
+		},
+		message: "Camera framed on target. Take capture_screenshot now.",
+	};
+}
+
 function executeLuau(requestData: Record<string, unknown>) {
 	const code = requestData.code as string;
 	if (!code || code === "") return { error: "Code is required" };
@@ -90,7 +223,9 @@ function executeLuau(requestData: Record<string, unknown>) {
 }
 
 export = {
-    getAttributes,
-    getSelection,
-    executeLuau,
+	getAttributes,
+	getSelection,
+	setSelection,
+	focusViewport,
+	executeLuau,
 };

--- a/tests/studio-tooling-smoke.mjs
+++ b/tests/studio-tooling-smoke.mjs
@@ -184,12 +184,22 @@ async function runEditModeToolSmoke(client, instanceId) {
     'delete_script_lines',
     'find_and_replace_in_scripts',
     'get_attributes',
-    'get_selection',
+    'selection',
     'execute_luau',
   ]) {
     assert(names.has(tool), `tools/list exposes ${tool}`);
   }
-  for (const removed of ['get_services', 'create_object', 'set_property', 'set_attribute', 'add_tag', 'delete_object']) {
+  for (const removed of [
+    'get_services',
+    'create_object',
+    'set_property',
+    'set_attribute',
+    'add_tag',
+    'delete_object',
+    'get_selection',
+    'set_selection',
+    'focus_viewport',
+  ]) {
     assert(!names.has(removed), `tools/list omits removed ${removed}`);
   }
 
@@ -384,8 +394,37 @@ return document:GetText()
     assert(exec.success === true, 'execute_luau edit target succeeds');
     assert(String(exec.returnValue) === 'true', 'execute_luau can read edited Workspace state');
 
-    const selection = await client.callTool('get_selection', { instance_id: instanceId });
-    assertNoError(selection, 'get_selection succeeds');
+    const viewed = await client.callTool('selection', {
+      action: 'view',
+      path: partPath,
+      padding: 1.1,
+      instance_id: instanceId,
+    });
+    assert(viewed.success === true && viewed.cameraPosition, 'selection view frames the smoke part');
+
+    const selected = await client.callTool('selection', {
+      action: 'set',
+      paths: [partPath],
+      instance_id: instanceId,
+    });
+    assert(selected.success === true && selected.selected === 1, 'selection set selects the smoke part');
+
+    const selection = await client.callTool('selection', {
+      action: 'get',
+      instance_id: instanceId,
+    });
+    assertNoError(selection, 'selection get succeeds');
+    assert(
+      selection.selection?.some((entry) => entry.path === partPath),
+      'selection get returns the smoke part',
+    );
+
+    const cleared = await client.callTool('selection', {
+      action: 'set',
+      paths: [],
+      instance_id: instanceId,
+    });
+    assert(cleared.success === true && cleared.selected === 0, 'selection set clears with empty paths');
   } finally {
     const deleted = await client.callTool('execute_luau', {
       target: 'edit',


### PR DESCRIPTION
`capture_screenshot` supports an inspect-your-work loop, but the catalog previously had no focused way to aim the viewport first. Selection had the same asymmetry: `get_selection` could read it, but nothing could update it.

This replaces that one-sided read with a canonical `selection` lifecycle tool:

- **`action="get"`** reads the current Studio selection.
- **`action="set"`** replaces, adds to, or removes from the selection by canonical path. An empty `paths` array in set mode clears it.
- **`action="view"`** frames a `BasePart` or `Model`. It preserves the current viewing direction unless `from` or `angleY` overrides it, uses `Camera:ZoomToExtents()` to fit the full bounds, and applies optional `padding`.

Viewport framing follows the same peer selection as `capture_screenshot`: edit mode when stopped and the live client during a playtest. The client broker both admits and dispatches the framing endpoint, so the next screenshot reads the camera that was actually moved.

### Version 3 token contract

The branch is rebased onto v3.0.0. Regression tests enforce the fixed catalog and description limits, and the shared runtime projects structured output schemas and behavior annotations.

Detailed selection and screenshot sequencing lives in `robloxstudio://tool-guides` and conditional server instructions instead of each tool description. `selection` is side-effecting, non-destructive, and idempotent. It stays in the Inspector catalog because it changes editor selection and camera state, not scripts or the DataModel.

The old `get_selection` name is removed from the catalog and direct HTTP routes and documented as `selection` with `action="get"` in the v3 migration table.

### Review fixes included

- Empty set-mode paths now call `Selection.Set([])` instead of returning an error.
- All-missing non-empty paths still fail rather than accidentally clearing selection.
- Camera framing uses the engine's full-bounds fit instead of a longest-edge radius that could crop corners.
- Get/set route explicitly to the edit peer; view routes to the same live viewport used by screenshots.
- Public constraints for target type, path length, padding, elevation, and compass semantics are encoded or documented in the schema.
- Focused regression coverage exercises lifecycle dispatch, validation, Inspector exposure, broker allowlisting, catalog budgets, and the Studio release smoke's view/set/get/clear flow.

### Verification

Passed locally:

- `npm test`
- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm run test:studio:runner`
- `git diff --check origin/main`