### PR TITLE
Fix #28, #29

### DIFF
--- a/studio-plugin/src/modules/handlers/MicroProfilerHandlers.ts
+++ b/studio-plugin/src/modules/handlers/MicroProfilerHandlers.ts
@@ -128,6 +128,8 @@ const DEFAULT_MAX_TIMERS_PER_GROUP = 5;
 const DEFAULT_MAX_RELATED_TIMERS = 3;
 const DEFAULT_MAX_EVENTS = 250000;
 const MAX_EVENTS = 1000000;
+const COOPERATIVE_CLOCK_CHECK_INTERVAL = 128;
+const MAX_COOPERATIVE_SLICE_SECONDS = 0.008;
 const DEFAULT_FRAME_WINDOW = 240;
 const BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 const PAD_BYTE = string.byte("=")[0];
@@ -147,6 +149,66 @@ const FOCUS_GROUP_MASKS: Record<string, string[]> = {
 };
 
 let cachedLibMP: LibMPLike | undefined;
+
+type CooperativeCheckpoint = () => void;
+
+// Sampling the clock avoids a timing call for every event while still bounding
+// each VM resumption. Sorting uses the same checkpoint so no full sort is atomic.
+
+function createCooperativeCheckpoint(): CooperativeCheckpoint {
+	let operationsSinceClockCheck = 0;
+	let sliceStartedAt = os.clock();
+
+	return () => {
+		operationsSinceClockCheck += 1;
+		if (operationsSinceClockCheck < COOPERATIVE_CLOCK_CHECK_INTERVAL) return;
+
+		operationsSinceClockCheck = 0;
+		if (os.clock() - sliceStartedAt < MAX_COOPERATIVE_SLICE_SECONDS) return;
+
+		task.wait();
+		sliceStartedAt = os.clock();
+	};
+}
+
+function cooperativeSort<T>(
+	values: T[],
+	comesBefore: (left: T, right: T) => boolean,
+	checkpoint: CooperativeCheckpoint,
+): void {
+	const count = values.size();
+	if (count < 2) return;
+
+	function siftDown(start: number, lastIndex: number): void {
+		let root = start;
+		while (root * 2 + 1 <= lastIndex) {
+			checkpoint();
+			let candidate = root;
+			const left = root * 2 + 1;
+			if (comesBefore(values[candidate], values[left])) candidate = left;
+			const right = left + 1;
+			if (right <= lastIndex && comesBefore(values[candidate], values[right])) candidate = right;
+			if (candidate === root) return;
+
+			const value = values[root];
+			values[root] = values[candidate];
+			values[candidate] = value;
+			root = candidate;
+		}
+	}
+
+	for (let start = math.floor((count - 2) / 2); start >= 0; start--) {
+		siftDown(start, count - 1);
+		checkpoint();
+	}
+	for (let lastIndex = count - 1; lastIndex > 0; lastIndex--) {
+		const value = values[0];
+		values[0] = values[lastIndex];
+		values[lastIndex] = value;
+		checkpoint();
+		siftDown(0, lastIndex - 1);
+	}
+}
 
 function normalizeDurationMs(value: unknown): number {
 	if (!typeIs(value, "number")) return DEFAULT_DURATION_MS;
@@ -246,7 +308,11 @@ function addFrameRaw(map: Map<number, number>, frameId: number, raw: number): vo
 	map.set(frameId, (map.get(frameId) ?? 0) + raw);
 }
 
-function summarizeFrameImpact(frameRawById: Map<number, number> | undefined, analyzedFrames: number): Record<string, unknown> {
+function summarizeFrameImpact(
+	frameRawById: Map<number, number> | undefined,
+	analyzedFrames: number,
+	checkpoint: CooperativeCheckpoint,
+): Record<string, unknown> {
 	if (frameRawById === undefined || frameRawById.size() === 0) {
 		return {
 			active_frame_count: 0,
@@ -262,6 +328,7 @@ function summarizeFrameImpact(frameRawById: Map<number, number> | undefined, ana
 	let maxUs = 0;
 	let maxFrameId = 0;
 	for (const [frameId, raw] of frameRawById) {
+		checkpoint();
 		const us = rawToUs(raw);
 		values.push(us);
 		totalUs += us;
@@ -270,7 +337,7 @@ function summarizeFrameImpact(frameRawById: Map<number, number> | undefined, ana
 			maxFrameId = frameId;
 		}
 	}
-	values.sort((a, b) => a < b);
+	cooperativeSort(values, (a, b) => a < b, checkpoint);
 
 	return {
 		active_frame_count: values.size(),
@@ -283,7 +350,7 @@ function summarizeFrameImpact(frameRawById: Map<number, number> | undefined, ana
 	};
 }
 
-function encodeBase64(buf: buffer): string {
+function encodeBase64(buf: buffer, checkpoint: CooperativeCheckpoint): string {
 	const len = buffer.len(buf);
 	const fullTriples = math.floor(len / 3);
 	const remaining = len - fullTriples * 3;
@@ -305,6 +372,7 @@ function encodeBase64(buf: buffer): string {
 
 		si += 3;
 		di += 4;
+		checkpoint();
 	}
 
 	if (remaining === 2) {
@@ -386,13 +454,19 @@ function recommendedToolsForGroups(groups: Record<string, unknown>[], targetRole
 	return tools;
 }
 
-function collectFrameSummary(session: LibMPSession, startFrame: number, frameMax: number): Record<string, unknown> {
+function collectFrameSummary(
+	session: LibMPSession,
+	startFrame: number,
+	frameMax: number,
+	checkpoint: CooperativeCheckpoint,
+): Record<string, unknown> {
 	const frameRows: Record<string, unknown>[] = [];
 	const durations: number[] = [];
 	let incompleteFrames = 0;
 	let pausedFrames = 0;
 
 	for (let frameId = startFrame; frameId <= frameMax; frameId++) {
+		checkpoint();
 		const [ok, descOrErr] = safeCall(() => session.GetFrameDesc(frameId));
 		if (!ok || !descOrErr) continue;
 		const desc = descOrErr as FrameDesc;
@@ -415,11 +489,14 @@ function collectFrameSummary(session: LibMPSession, startFrame: number, frameMax
 		frameRows.push(row);
 	}
 
-	durations.sort((a, b) => a < b);
-	frameRows.sort((a, b) => (a.duration_us as number) > (b.duration_us as number));
+	cooperativeSort(durations, (a, b) => a < b, checkpoint);
+	cooperativeSort(frameRows, (a, b) => (a.duration_us as number) > (b.duration_us as number), checkpoint);
 
 	let totalUs = 0;
-	for (const duration of durations) totalUs += duration;
+	for (const duration of durations) {
+		totalUs += duration;
+		checkpoint();
+	}
 
 	const topFrames: Record<string, unknown>[] = [];
 	for (let i = 0; i < math.min(10, frameRows.size()); i++) {
@@ -642,6 +719,8 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 		};
 	}
 
+	const checkpoint = createCooperativeCheckpoint();
+
 	const stacks = new Map<number, StackEntry[]>();
 	const aggregates = new Map<number, TimerAggregate>();
 	const timerThreadAggregates = new Map<number, Map<number, TimerAggregate>>();
@@ -658,7 +737,9 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 	let lastProcessedFrameId: number | undefined;
 	let lastProcessedTimestampRaw: number | undefined;
 
-	while (eventsSampled < maxEvents && iterator.Step()) {
+	while (eventsSampled < maxEvents) {
+		checkpoint();
+		if (!iterator.Step()) break;
 		eventsSampled += 1;
 		const state = iterator.GetState();
 		if (!state) continue;
@@ -686,6 +767,7 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 			exitEvents += 1;
 			let entry: StackEntry | undefined;
 			while (stack.size() > 0) {
+				checkpoint();
 				const candidate = stack.pop();
 				if (candidate && candidate.timerId === timerId) {
 					entry = candidate;
@@ -735,7 +817,7 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 	const sampledFrameCoveragePct = percent(sampledFrames.size(), framesConsidered);
 	const analysisFrameMin = sampledFrameMin ?? startFrame;
 	const analysisFrameMax = sampledFrameMax ?? frameMax;
-	const frameSummary = collectFrameSummary(session, analysisFrameMin, analysisFrameMax);
+	const frameSummary = collectFrameSummary(session, analysisFrameMin, analysisFrameMax, checkpoint);
 	const analysisFrameCount = typeIs(frameSummary.frames, "number") && (frameSummary.frames as number) > 0
 		? frameSummary.frames as number
 		: sampledFrames.size() > 0
@@ -758,6 +840,7 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 	let omittedByFilter = 0;
 
 	for (const [timerId, aggregate] of aggregates) {
+		checkpoint();
 		const info = getTimerInfo(timerId);
 		const totalUs = rawToUs(aggregate.inclusive_raw);
 		if (!includeIdle && isIdleTimer(info)) {
@@ -807,7 +890,7 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 		};
 		const maxToAvg = ratio(maxUs, avgUs);
 		if (maxToAvg !== undefined) row.max_to_avg = maxToAvg;
-		const timerFrameImpact = summarizeFrameImpact(timerFrameAggregates.get(timerId), analysisFrameCount);
+		const timerFrameImpact = summarizeFrameImpact(timerFrameAggregates.get(timerId), analysisFrameCount, checkpoint);
 		for (const [key, value] of pairs(timerFrameImpact)) {
 			row[key as string] = value;
 		}
@@ -827,13 +910,17 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 				groupFrames = new Map<number, number>();
 				groupFrameAggregates.set(group, groupFrames);
 			}
-			for (const [frameId, raw] of timerFrames) addFrameRaw(groupFrames, frameId, raw);
+			for (const [frameId, raw] of timerFrames) {
+				addFrameRaw(groupFrames, frameId, raw);
+				checkpoint();
+			}
 		}
 
 		const perThread = timerThreadAggregates.get(timerId);
 		if (perThread !== undefined) {
 			const timerThreadSummaryRows: Record<string, unknown>[] = [];
 			for (const [threadId, threadAggregate] of perThread) {
+				checkpoint();
 				let threadAggregateRow = threadAggregates.get(threadId);
 				if (threadAggregateRow === undefined) {
 					threadAggregateRow = { timer_id: threadId, inclusive_raw: 0, exclusive_raw: 0, count: 0, max_raw: 0 };
@@ -880,7 +967,7 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 					count: threadAggregate.count,
 				});
 			}
-			timerThreadSummaryRows.sort((a, b) => (a.inclusive_us as number) > (b.inclusive_us as number));
+			cooperativeSort(timerThreadSummaryRows, (a, b) => (a.inclusive_us as number) > (b.inclusive_us as number), checkpoint);
 			if (maxRelatedTimers > 0 && timerThreadSummaryRows.size() > 0) {
 				const topTimerThreads: Record<string, unknown>[] = [];
 				for (let i = 0; i < math.min(maxRelatedTimers, timerThreadSummaryRows.size()); i++) topTimerThreads.push(timerThreadSummaryRows[i]);
@@ -889,12 +976,13 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 		}
 	}
 
-	rows.sort((a, b) => (a.inclusive_us as number) > (b.inclusive_us as number));
+	cooperativeSort(rows, (a, b) => (a.inclusive_us as number) > (b.inclusive_us as number), checkpoint);
 
 	const edgeRows: Record<string, unknown>[] = [];
 	const parentRelationsByChild = new Map<number, Record<string, unknown>[]>();
 	const childRelationsByParent = new Map<number, Record<string, unknown>[]>();
 	for (const [, edge] of edgeAggregates) {
+		checkpoint();
 		const parentRow = rowsByTimerId.get(edge.parent_timer_id);
 		const childRow = rowsByTimerId.get(edge.child_timer_id);
 		if (parentRow === undefined || childRow === undefined) continue;
@@ -951,15 +1039,18 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 			pct_of_timer_inclusive: percent(inclusiveUs, parentRow.inclusive_us as number),
 		});
 	}
-	edgeRows.sort((a, b) => (a.inclusive_us as number) > (b.inclusive_us as number));
+	cooperativeSort(edgeRows, (a, b) => (a.inclusive_us as number) > (b.inclusive_us as number), checkpoint);
 	if (maxRelatedTimers > 0) {
 		for (const [, relationRows] of parentRelationsByChild) {
-			relationRows.sort((a, b) => (a.inclusive_us as number) > (b.inclusive_us as number));
+			checkpoint();
+			cooperativeSort(relationRows, (a, b) => (a.inclusive_us as number) > (b.inclusive_us as number), checkpoint);
 		}
 		for (const [, relationRows] of childRelationsByParent) {
-			relationRows.sort((a, b) => (a.inclusive_us as number) > (b.inclusive_us as number));
+			checkpoint();
+			cooperativeSort(relationRows, (a, b) => (a.inclusive_us as number) > (b.inclusive_us as number), checkpoint);
 		}
 		for (const row of rows) {
+			checkpoint();
 			const timerId = row.timer_id as number;
 			const parents = parentRelationsByChild.get(timerId);
 			const children = childRelationsByParent.get(timerId);
@@ -984,8 +1075,11 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 	}
 
 	const rowsByExclusive: Record<string, unknown>[] = [];
-	for (const row of rows) rowsByExclusive.push(row);
-	rowsByExclusive.sort((a, b) => (a.exclusive_us as number) > (b.exclusive_us as number));
+	for (const row of rows) {
+		rowsByExclusive.push(row);
+		checkpoint();
+	}
+	cooperativeSort(rowsByExclusive, (a, b) => (a.exclusive_us as number) > (b.exclusive_us as number), checkpoint);
 	const topTimersByExclusive: Record<string, unknown>[] = [];
 	for (let i = 0; i < math.min(maxTimers, rowsByExclusive.size()); i++) {
 		const row = copyRecord(rowsByExclusive[i]);
@@ -1002,6 +1096,7 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 
 	const threadRows: Record<string, unknown>[] = [];
 	for (const [threadId, aggregate] of threadAggregates) {
+		checkpoint();
 		const info = getThreadInfo(threadId);
 		const inclusiveUs = rawToUs(aggregate.inclusive_raw);
 		const exclusiveUs = rawToUs(aggregate.exclusive_raw);
@@ -1019,7 +1114,7 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 			pct_of_analyzed_wall: percent(inclusiveUs, analysisDurationUs),
 		};
 		const timerRows = threadTimerRows.get(threadId) ?? [];
-		timerRows.sort((a, b) => (a.inclusive_us as number) > (b.inclusive_us as number));
+		cooperativeSort(timerRows, (a, b) => (a.inclusive_us as number) > (b.inclusive_us as number), checkpoint);
 		const topThreadTimers: Record<string, unknown>[] = [];
 		for (let i = 0; i < math.min(maxTimersPerGroup, timerRows.size()); i++) {
 			const timerRow = copyRecord(timerRows[i]);
@@ -1028,7 +1123,7 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 		if (topThreadTimers.size() > 0) row.top_timers = topThreadTimers;
 		threadRows.push(row);
 	}
-	threadRows.sort((a, b) => (a.inclusive_us as number) > (b.inclusive_us as number));
+	cooperativeSort(threadRows, (a, b) => (a.inclusive_us as number) > (b.inclusive_us as number), checkpoint);
 	const topThreads: Record<string, unknown>[] = [];
 	for (let i = 0; i < math.min(maxGroups, threadRows.size()); i++) {
 		const row = threadRows[i];
@@ -1038,8 +1133,9 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 
 	const groupRows: Record<string, unknown>[] = [];
 	for (const [, aggregate] of groupAggregates) {
+		checkpoint();
 		const timerRows = groupTimerRows.get(aggregate.group) ?? [];
-		timerRows.sort((a, b) => (a.inclusive_us as number) > (b.inclusive_us as number));
+		cooperativeSort(timerRows, (a, b) => (a.inclusive_us as number) > (b.inclusive_us as number), checkpoint);
 		const topGroupTimers: Record<string, unknown>[] = [];
 		for (let i = 0; i < math.min(maxTimersPerGroup, timerRows.size()); i++) {
 			const timerRow = timerRows[i];
@@ -1068,14 +1164,14 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 			timer_count: timerRows.size(),
 			pct_of_analyzed_wall: percent(inclusiveUs, analysisDurationUs),
 		};
-		const groupFrameImpact = summarizeFrameImpact(groupFrameAggregates.get(aggregate.group), analysisFrameCount);
+		const groupFrameImpact = summarizeFrameImpact(groupFrameAggregates.get(aggregate.group), analysisFrameCount, checkpoint);
 		for (const [key, value] of pairs(groupFrameImpact)) {
 			groupRow[key as string] = value;
 		}
 		if (topGroupTimers.size() > 0) groupRow.top_timers = topGroupTimers;
 		groupRows.push(groupRow);
 	}
-	groupRows.sort((a, b) => (a.inclusive_us as number) > (b.inclusive_us as number));
+	cooperativeSort(groupRows, (a, b) => (a.inclusive_us as number) > (b.inclusive_us as number), checkpoint);
 	const topGroups: Record<string, unknown>[] = [];
 	for (let i = 0; i < math.min(maxGroups, groupRows.size()); i++) {
 		const row = copyRecord(groupRows[i]);
@@ -1084,8 +1180,11 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 	}
 
 	const groupRowsByExclusive: Record<string, unknown>[] = [];
-	for (const row of groupRows) groupRowsByExclusive.push(row);
-	groupRowsByExclusive.sort((a, b) => (a.exclusive_us as number) > (b.exclusive_us as number));
+	for (const row of groupRows) {
+		groupRowsByExclusive.push(row);
+		checkpoint();
+	}
+	cooperativeSort(groupRowsByExclusive, (a, b) => (a.exclusive_us as number) > (b.exclusive_us as number), checkpoint);
 	const topGroupsByExclusive: Record<string, unknown>[] = [];
 	for (let i = 0; i < math.min(maxGroups, groupRowsByExclusive.size()); i++) {
 		const row = copyRecord(groupRowsByExclusive[i]);
@@ -1099,7 +1198,10 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 	if (omittedByFilter > 0) omitted.filtered_out = omittedByFilter;
 
 	let openStackEntriesAtEnd = 0;
-	for (const [, stack] of stacks) openStackEntriesAtEnd += stack.size();
+	for (const [, stack] of stacks) {
+		openStackEntriesAtEnd += stack.size();
+		checkpoint();
+	}
 	const iteratorFinished = eventsSampled < maxEvents;
 	const partialReasons: string[] = [];
 	if (eventsSampled >= maxEvents) partialReasons.push("event_limit_hit");
@@ -1151,13 +1253,25 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 			"max_invocation_us",
 		];
 		const timerIndex: Record<string, unknown>[] = [];
-		for (const row of rows) timerIndex.push(pickFields(row, timerFields));
+		for (const row of rows) {
+			timerIndex.push(pickFields(row, timerFields));
+			checkpoint();
+		}
 		const groupIndex: Record<string, unknown>[] = [];
-		for (const row of groupRows) groupIndex.push(pickFields(row, groupFields));
+		for (const row of groupRows) {
+			groupIndex.push(pickFields(row, groupFields));
+			checkpoint();
+		}
 		const threadIndex: Record<string, unknown>[] = [];
-		for (const row of threadRows) threadIndex.push(pickFields(row, threadFields));
+		for (const row of threadRows) {
+			threadIndex.push(pickFields(row, threadFields));
+			checkpoint();
+		}
 		const edgeIndex: Record<string, unknown>[] = [];
-		for (const row of edgeRows) edgeIndex.push(pickFields(row, edgeFields));
+		for (const row of edgeRows) {
+			edgeIndex.push(pickFields(row, edgeFields));
+			checkpoint();
+		}
 		comparisonIndex = {
 			timers: timerIndex,
 			groups: groupIndex,
@@ -1253,7 +1367,7 @@ function captureMicroProfiler(requestData: Record<string, unknown>): unknown {
 	result.backend = backend;
 	if (session.GetDataFormatVersion() !== undefined) result.libmp_data_format_version = session.GetDataFormatVersion();
 	if (session.GetObjSize() !== undefined) result.snapshot_object_size_bytes = session.GetObjSize();
-	if (includeRawBuffer) result.raw_snapshot_base64 = encodeBase64(snapshot);
+	if (includeRawBuffer) result.raw_snapshot_base64 = encodeBase64(snapshot, checkpoint);
 
 	iterator.Dispose();
 	session.Dispose();

--- a/studio-plugin/src/modules/handlers/ScriptHandlers.ts
+++ b/studio-plugin/src/modules/handlers/ScriptHandlers.ts
@@ -110,9 +110,9 @@ function getScriptSource(requestData: Record<string, unknown>) {
 
 function setScriptSource(requestData: Record<string, unknown>) {
 	const instancePath = requestData.instancePath as string;
-	const newSource = requestData.source as string;
+	const newSource = requestData.source;
 
-	if (!instancePath || !newSource) return { error: "Instance path and source are required" };
+	if (!instancePath || !typeIs(newSource, "string")) return { error: "Instance path and source are required" };
 
 	const instance = getInstanceByPath(instancePath);
 	if (!instance) return { error: `Instance not found: ${instancePath}` };

--- a/tests/micro-profiler-responsiveness.mjs
+++ b/tests/micro-profiler-responsiveness.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdtempSync, rmSync, statSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { McpClient, assert, runTest, startPlaytestAndWait } from './lib/mcp-client.mjs';
+
+const MAX_CONCURRENT_RESPONSE_MS = 3000;
+const CAPTURE_DURATION_MS = 5000;
+const MAX_EVENTS = 1_000_000;
+
+function assertDescending(rows, field, label) {
+  if (!Array.isArray(rows)) throw new Error(`${label}: expected an array`);
+  for (let index = 1; index < rows.length; index += 1) {
+    const previous = Number(rows[index - 1]?.[field]);
+    const current = Number(rows[index]?.[field]);
+    if (Number.isFinite(previous) && Number.isFinite(current) && previous < current) {
+      throw new Error(`${label}: ${field} increased at rows ${index} and ${index + 1} (${previous} < ${current})`);
+    }
+  }
+  assert(true, `${label} remains sorted by ${field} descending`);
+}
+
+async function waitForRuntimePeersToDrain(client, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last;
+  while (Date.now() < deadline) {
+    last = await client.callTool('get_connected_instances', {});
+    const instance = (last.instances ?? []).find((row) => row.id === process.env.MCP_INSTANCE_ID);
+    if (instance && !instance.roles.some((role) => role === 'server' || role.startsWith('client-'))) return;
+    await delay(250);
+  }
+  throw new Error(`runtime peers did not drain after playtest stop: ${JSON.stringify(last)}`);
+}
+
+function newSevereProfilerLogs(logs) {
+  const entries = Array.isArray(logs?.entries) ? logs.entries : [];
+  return entries.filter((entry) => {
+    const message = String(entry?.message ?? '');
+    const severity = String(entry?.level ?? entry?.messageType ?? entry?.type ?? '');
+    return /micro.?profiler|robloxstudio-mcp/i.test(message)
+      && /error|exception|timeout|failed/i.test(`${severity} ${message}`);
+  });
+}
+
+await runTest('high-volume MicroProfiler capture remains cooperative', async ({ track }) => {
+  const client = track(new McpClient('micro-profiler-responsiveness'));
+  const outputDirectory = mkdtempSync(path.join(os.tmpdir(), 'rsmcp-profiler-responsive-'));
+  const rawOutputPath = path.join(outputDirectory, 'capture.mp');
+  const cleanupErrors = [];
+  let bodyError;
+  let playtestStarted = false;
+  let capturePromise;
+
+  try {
+    await client.start();
+    await client.initialize();
+    playtestStarted = true;
+    await startPlaytestAndWait(client, { timeoutSec: 60 });
+
+    const serverLogBaseline = await client.callTool('get_runtime_logs', { target: 'server', tail: 1 });
+    const editLogBaseline = await client.callTool('get_runtime_logs', { target: 'edit', tail: 1 });
+    const serverSince = Number.isFinite(serverLogBaseline.nextSince) ? serverLogBaseline.nextSince : 0;
+    const editSince = Number.isFinite(editLogBaseline.nextSince) ? editLogBaseline.nextSince : 0;
+
+    const preflight = await client.callTool('execute_luau', {
+      target: 'server',
+      code: 'return "RSMCP_PROFILER_PREFLIGHT"',
+    });
+    assert(
+      preflight.success === true && String(preflight.returnValue) === 'RSMCP_PROFILER_PREFLIGHT',
+      'server peer accepts an adjacent request before profiling',
+    );
+
+    let captureSettled = false;
+    const captureStartedAt = Date.now();
+    capturePromise = client.callTool('capture_micro_profiler', {
+      target: 'server',
+      duration_ms: CAPTURE_DURATION_MS,
+      focus: 'all',
+      max_timers: 100,
+      max_groups: 100,
+      max_timers_per_group: 20,
+      max_related_timers: 10,
+      max_events: MAX_EVENTS,
+      frame_window: 2000,
+      include_idle: true,
+      include_gpu: true,
+      output_path: rawOutputPath,
+    }, 120_000).finally(() => {
+      captureSettled = true;
+    });
+
+    await delay(CAPTURE_DURATION_MS - 500);
+    const probes = [];
+    while (!captureSettled && probes.length < 50 && Date.now() - captureStartedAt < 60_000) {
+      const issuedAt = Date.now();
+      const [serverProbe, pluginProbe] = await Promise.all([
+        client.callTool('get_connected_instances', {}, 5000),
+        client.callTool('execute_luau', {
+          target: 'server',
+          code: 'return "RSMCP_CONCURRENT_RESPONSIVE"',
+        }, 5000),
+      ]);
+      const latencyMs = Date.now() - issuedAt;
+      if (!Array.isArray(serverProbe.instances) || serverProbe.instances.length === 0) {
+        throw new Error(`MCP server probe failed during capture: ${JSON.stringify(serverProbe)}`);
+      }
+      if (pluginProbe.success !== true || String(pluginProbe.returnValue) !== 'RSMCP_CONCURRENT_RESPONSIVE') {
+        throw new Error(`runtime plugin probe failed during capture: ${JSON.stringify(pluginProbe)}`);
+      }
+      probes.push({ offsetMs: issuedAt - captureStartedAt, latencyMs });
+      await delay(25);
+    }
+
+    const capture = await capturePromise;
+    const captureElapsedMs = Date.now() - captureStartedAt;
+    assert(capture.ok === true && !capture.error,
+      `high-volume capture_micro_profiler succeeds (${JSON.stringify({ error: capture.error, counts: capture.counts })})`);
+    assert(capture.applied?.max_events === MAX_EVENTS && capture.applied?.frame_window === 2000,
+      'high-volume capture applies the requested event and frame limits');
+    assert(Number.isInteger(capture.counts?.events_sampled) && capture.counts.events_sampled > 0,
+      `high-volume capture samples events (${capture.counts?.events_sampled})`);
+    assert(probes.length > 0, `at least one responsiveness probe overlaps the capture (${JSON.stringify(probes)})`);
+    assert(probes.some((probe) => probe.offsetMs >= CAPTURE_DURATION_MS),
+      `a responsiveness probe overlaps post-capture analysis (${JSON.stringify(probes)})`);
+    const maxProbeLatencyMs = Math.max(...probes.map((probe) => probe.latencyMs));
+    assert(maxProbeLatencyMs < MAX_CONCURRENT_RESPONSE_MS,
+      `concurrent server/plugin latency stays below ${MAX_CONCURRENT_RESPONSE_MS}ms (max=${maxProbeLatencyMs}ms)`);
+    assert(captureElapsedMs < 30_000,
+      `high-volume capture completes before the 30s plugin bridge timeout (${captureElapsedMs}ms)`);
+    assert(existsSync(rawOutputPath) && statSync(rawOutputPath).size > 0,
+      `raw profiler snapshot is written (${statSync(rawOutputPath).size} bytes)`);
+
+    assertDescending(capture.top_timers, 'inclusive_us', 'cooperative timer sort');
+    assertDescending(capture.top_timers_by_exclusive, 'exclusive_us', 'cooperative exclusive timer sort');
+    assertDescending(capture.top_groups, 'inclusive_us', 'cooperative group sort');
+    assertDescending(capture.top_call_edges, 'inclusive_us', 'cooperative call-edge sort');
+    assertDescending(capture.frame_summary?.top_frames, 'duration_us', 'cooperative frame sort');
+
+    const adjacentCapture = await client.callTool('capture_micro_profiler', {
+      target: 'server',
+      duration_ms: 100,
+      max_events: 10_000,
+      frame_window: 30,
+      max_timers: 5,
+      max_groups: 5,
+      max_timers_per_group: 0,
+      max_related_timers: 0,
+    }, 60_000);
+    assert(adjacentCapture.ok === true && adjacentCapture.counts?.events_sampled > 0,
+      `a follow-up bounded profiler capture succeeds (${JSON.stringify(adjacentCapture.counts)})`);
+
+    const after = await client.callTool('execute_luau', {
+      target: 'server',
+      code: 'return "RSMCP_PROFILER_AFTER"',
+    });
+    assert(after.success === true && String(after.returnValue) === 'RSMCP_PROFILER_AFTER',
+      'server peer remains usable after profiler cleanup');
+
+    const [serverLogs, editLogs] = await Promise.all([
+      client.callTool('get_runtime_logs', { target: 'server', since: serverSince, tail: 200 }),
+      client.callTool('get_runtime_logs', { target: 'edit', since: editSince, tail: 200 }),
+    ]);
+    const severeLogs = [...newSevereProfilerLogs(serverLogs), ...newSevereProfilerLogs(editLogs)];
+    assert(severeLogs.length === 0,
+      `runtime logs contain no new profiler/plugin timeout or error (${JSON.stringify(severeLogs)})`);
+    console.log(
+      `  capture elapsed=${captureElapsedMs}ms events=${capture.counts.events_sampled} ` +
+      `buffer=${capture.counts.buffer_bytes} maxProbeLatency=${maxProbeLatencyMs}ms ` +
+      `runtimeLogs=${(serverLogs.entries ?? []).length + (editLogs.entries ?? []).length}`,
+    );
+  } catch (error) {
+    bodyError = error;
+    throw error;
+  } finally {
+    if (capturePromise) {
+      try {
+        await capturePromise;
+      } catch (error) {
+        if (error !== bodyError) {
+          cleanupErrors.push(error instanceof Error ? error : new Error(String(error)));
+        }
+      }
+    }
+    if (playtestStarted) {
+      try {
+        const stopped = await client.callTool('solo_playtest', { action: 'stop' }, 30_000);
+        if (stopped.success !== true) throw new Error(`solo_playtest stop failed: ${JSON.stringify(stopped)}`);
+        await waitForRuntimePeersToDrain(client);
+      } catch (error) {
+        cleanupErrors.push(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+    try {
+      rmSync(outputDirectory, { recursive: true, force: true });
+    } catch (error) {
+      cleanupErrors.push(error instanceof Error ? error : new Error(String(error)));
+    }
+    if (cleanupErrors.length > 0) {
+      if (bodyError) {
+        throw new AggregateError([bodyError, ...cleanupErrors], 'profiler regression and cleanup failed', { cause: bodyError });
+      }
+      throw new AggregateError(cleanupErrors, 'profiler regression cleanup failed');
+    }
+  }
+}).then((ok) => process.exit(ok ? 0 : 1));

--- a/tests/run-all.mjs
+++ b/tests/run-all.mjs
@@ -36,6 +36,7 @@ const FULL_TESTS = [
   'eval-bridge-error-preservation.mjs',
   'eval-context-routing.mjs',
   'runtime-bridge-lifecycle.mjs',
+  'micro-profiler-responsiveness.mjs',
   'execute-luau-error-preservation.mjs',
   'proxy-mode-peer-fanout.mjs',
   'execute-luau-output-capture.mjs',
@@ -46,6 +47,7 @@ const FULL_TESTS = [
 const FEATURE_TESTS = [
   'studio-tooling-smoke.mjs',
   'eval-context-routing.mjs',
+  'micro-profiler-responsiveness.mjs',
 ];
 const featureSmoke = process.argv.includes('--smoke');
 const TESTS = featureSmoke ? FEATURE_TESTS : FULL_TESTS;

--- a/tests/studio-tooling-smoke.mjs
+++ b/tests/studio-tooling-smoke.mjs
@@ -314,6 +314,36 @@ return document:GetText()
     assert(draftSource.source === '1: ',
       `get_script_source preserves an empty live editor draft (${JSON.stringify(draftSource)})`);
 
+    const populatedDraft = await client.callTool('set_script_source', {
+      instancePath: scriptPath,
+      source: 'local beforeClear = true\nreturn beforeClear\n',
+      instance_id: instanceId,
+    });
+    assert(populatedDraft.success === true && populatedDraft.method === 'UpdateSourceAsync',
+      `set_script_source populates the empty live editor draft editor-safely (${JSON.stringify(populatedDraft)})`);
+
+    const populatedRead = await client.callTool('get_script_source', {
+      instancePath: scriptPath,
+      instance_id: instanceId,
+    });
+    assertContains(populatedRead.source, 'return beforeClear',
+      'get_script_source confirms the live editor draft is non-empty before clearing');
+
+    const clearedSource = await client.callTool('set_script_source', {
+      instancePath: scriptPath,
+      source: '',
+      instance_id: instanceId,
+    });
+    assert(clearedSource.success === true && clearedSource.method === 'UpdateSourceAsync',
+      `set_script_source clears a non-empty live editor draft editor-safely (${JSON.stringify(clearedSource)})`);
+
+    const clearedRead = await client.callTool('get_script_source', {
+      instancePath: scriptPath,
+      instance_id: instanceId,
+    });
+    assert(clearedRead.source === '1: ',
+      `set_script_source cleared the non-empty live draft exactly (${JSON.stringify(clearedRead)})`);
+
     const restoredDraft = await client.callTool('set_script_source', {
       instancePath: scriptPath,
       source: 'local value = 40\nreturn value + 1\n',


### PR DESCRIPTION
Closes #28, closes #29

- set_script_source: accept an empty source string (`typeIs(source, "string")` instead of `!source`); added an empty-source case to the Studio tooling smoke test
- captureMicroProfiler: `task.wait()` every 20k events while stepping the iterator so large captures don't stall Studio

Unit tests pass (263/263), plugin compiles with rbxtsc.