### PR TITLE
fix(pack): only bundle each package's built plugin asset

### DIFF
--- a/packages/robloxstudio-mcp-inspector/package.json
+++ b/packages/robloxstudio-mcp-inspector/package.json
@@ -12,11 +12,11 @@
   },
   "files": [
     "dist/**/*",
-    "studio-plugin/**/*"
+    "studio-plugin/MCPInspectorPlugin.rbxmx"
   ],
   "scripts": {
     "build": "tsup",
-    "prepack": "node ../../scripts/prepack.mjs",
+    "prepack": "node ../../scripts/prepack.mjs MCPInspectorPlugin.rbxmx",
     "postpack": "node ../../scripts/postpack.mjs"
   },
   "keywords": [

--- a/packages/robloxstudio-mcp/package.json
+++ b/packages/robloxstudio-mcp/package.json
@@ -12,11 +12,11 @@
   },
   "files": [
     "dist/**/*",
-    "studio-plugin/**/*"
+    "studio-plugin/MCPPlugin.rbxmx"
   ],
   "scripts": {
     "build": "tsup",
-    "prepack": "node ../../scripts/prepack.mjs",
+    "prepack": "node ../../scripts/prepack.mjs MCPPlugin.rbxmx",
     "postpack": "node ../../scripts/postpack.mjs"
   },
   "keywords": [

--- a/scripts/prepack.mjs
+++ b/scripts/prepack.mjs
@@ -1,28 +1,37 @@
 #!/usr/bin/env node
 
 /**
- * Copies studio-plugin/ into the package directory before npm pack/publish.
- * Run from a publishable package directory via its "prepack" script.
+ * Copies a single built plugin asset from studio-plugin/ into the package
+ * directory before npm pack/publish. Run from a publishable package directory
+ * via its "prepack" script, passing the asset filename as an argument, e.g.
+ * "node ../../scripts/prepack.mjs MCPPlugin.rbxmx".
  */
 
-import { cpSync, existsSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { copyFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+const assetName = process.argv[2];
+if (!assetName) {
+  console.error('Usage: prepack.mjs <asset-filename>');
+  process.exit(1);
+}
 
 const packageDir = process.cwd();
 const rootDir = join(packageDir, '..', '..');
-const source = join(rootDir, 'studio-plugin');
-const dest = join(packageDir, 'studio-plugin');
+const source = join(rootDir, 'studio-plugin', assetName);
+const destDir = join(packageDir, 'studio-plugin');
+const dest = join(destDir, assetName);
 
 if (!existsSync(source)) {
-  console.error('studio-plugin/ not found at project root, skipping copy');
+  console.error(`${assetName} not found at project root studio-plugin/, skipping copy`);
   process.exit(0);
 }
 
 if (existsSync(dest)) {
-  console.log('studio-plugin/ already exists in package, skipping copy');
+  console.log(`${assetName} already exists in package, skipping copy`);
   process.exit(0);
 }
 
-console.log(`Copying studio-plugin/ into ${packageDir}`);
-cpSync(source, dest, { recursive: true });
+console.log(`Copying studio-plugin/${assetName} into ${packageDir}`);
+mkdirSync(destDir, { recursive: true });
+copyFileSync(source, dest);


### PR DESCRIPTION
Addresses https://github.com/Chrrxs/robloxstudio-mcp/issues/27

`prepack.mjs` was copying the entire `studio-plugin/` directory into both npm packages before publish, and each package's files field ("studio-plugin/**/*") shipped whatever got copied. That directory holds the full TypeScript source, dev configs, lockfiles, docs, and a ~4.8MB `include/LibMP.lua`, none of which the published packages actually need.