### PR TITLE
fix: add ESM shims and createRequire banner to tsup config

### DIFF
--- a/packages/robloxstudio-mcp-inspector/tsup.config.ts
+++ b/packages/robloxstudio-mcp-inspector/tsup.config.ts
@@ -9,9 +9,12 @@ export default defineConfig({
   bundle: true,
   splitting: false,
   clean: true,
-  noExternal: ['@chrrxs/robloxstudio-mcp-core'],
+  shims: true,
+  noExternal: [/(.*)/],
   banner: {
-    js: '#!/usr/bin/env node',
+    js: `#!/usr/bin/env node
+import { createRequire as __createRequire } from 'module';
+const require = __createRequire(import.meta.url);`,
   },
   onSuccess: async () => {
     const assetsDir = join('dist', 'assets');

--- a/packages/robloxstudio-mcp/tsup.config.ts
+++ b/packages/robloxstudio-mcp/tsup.config.ts
@@ -9,9 +9,12 @@ export default defineConfig({
   bundle: true,
   splitting: false,
   clean: true,
-  noExternal: ['@chrrxs/robloxstudio-mcp-core'],
+  shims: true,
+  noExternal: [/(.*)/],
   banner: {
-    js: '#!/usr/bin/env node',
+    js: `#!/usr/bin/env node
+import { createRequire as __createRequire } from 'module';
+const require = __createRequire(import.meta.url);`,
   },
   onSuccess: async () => {
     const assetsDir = join('dist', 'assets');


### PR DESCRIPTION
### Summary
Fixes startup crashes on Node 20+ caused by dynamic `require()` calls inside bundled dependencies:
`Error: Dynamic require of "path" is not supported`

### Changes
* Added `shims: true` in `tsup.config.ts` for both packages.
* Injected a `createRequire(import.meta.url)` banner so CommonJS `require` calls resolve correctly in ESM output.
* Set `noExternal: [/(.*)/]` so dependencies bundle into a standalone executable.

### Validation
* Tested on Node 20 and Node 22
* `npm run typecheck` (0 errors)
* `npm run build` (both `@chrrxs/robloxstudio-mcp` and `@chrrxs/robloxstudio-mcp-inspector` build cleanly)
* `npm run test:package-contents` (passed)