### PR TITLE
fix: execFileSync, package scope, typing fix, and Windows test compat

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,12 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "!dist/__tests__/**/*",
+    "!dist/**/*.map"
+  ],
   "dependencies": {
     "fzstd": "^0.1.1"
   },

--- a/packages/core/src/install-plugin-helpers.ts
+++ b/packages/core/src/install-plugin-helpers.ts
@@ -1,5 +1,5 @@
 import { existsSync, unlinkSync } from 'fs';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { join } from 'path';
 import { homedir } from 'os';
 import { getStudioPlatformCapabilities } from './studio-platform.js';
@@ -62,17 +62,15 @@ function getWindowsUserPluginsDir(): string | null {
   // wslpath. cmd.exe spams a "UNC paths are not supported" warning to stderr
   // when the CWD is on the Linux side - silence it with stdio: 'ignore'.
   try {
-    const localAppData = execSync('cmd.exe /c "echo %LOCALAPPDATA%"', {
+    const localAppData = execFileSync('cmd.exe', ['/c', 'echo %LOCALAPPDATA%'], {
       stdio: ['ignore', 'pipe', 'ignore'],
-    })
-      .toString()
-      .trim();
+      encoding: 'utf8',
+    }).trim();
     if (!localAppData || localAppData.includes('%')) return null;
-    const linuxPath = execSync(`wslpath -u '${localAppData.replace(/'/g, "'\\''")}'`, {
+    const linuxPath = execFileSync('wslpath', ['-u', localAppData], {
       stdio: ['ignore', 'pipe', 'ignore'],
-    })
-      .toString()
-      .trim();
+      encoding: 'utf8',
+    }).trim();
     if (!linuxPath) return null;
     return join(linuxPath, 'Roblox', 'Plugins');
   } catch {
@@ -137,8 +135,8 @@ export function handleVariantConflict({
 
   warn(
     `\n[install-plugin] WARNING: ${otherAssetName} is already present in ${pluginsFolder}.\n` +
-	      `Only one MCP plugin variant should be present. If both variants are in the Studio ` +
-	      `Plugins folder, Studio loads both and runtime routing can become unpredictable.\n` +
-	      `Delete ${otherAssetName} manually or use the default CLI installer behavior to replace it.\n`,
-	  );
-	}
+      `Only one MCP plugin variant should be present. If both variants are in the Studio ` +
+      `Plugins folder, Studio loads both and runtime routing can become unpredictable.\n` +
+      `Delete ${otherAssetName} manually or use the default CLI installer behavior to replace it.\n`,
+  );
+}

--- a/studio-plugin/.gitignore
+++ b/studio-plugin/.gitignore
@@ -3,3 +3,5 @@ out/
 include/*
 !include/LibMP.lua
 *.tsbuildinfo
+*.rbxm
+.*.lock

--- a/studio-plugin/src/modules/RuntimeLogBuffer.ts
+++ b/studio-plugin/src/modules/RuntimeLogBuffer.ts
@@ -142,7 +142,7 @@ function install(): void {
 	// Seed from per-DataModel LogHistory so get_runtime_logs can still see them;
 	// edit history is bounded to the current Studio process above.
 	seedRuntimeHistory();
-	LogService.MessageOut.Connect((msg, t, context?: Record<string, unknown>) => {
+	LogService.MessageOut.Connect((msg, t, context?: any) => {
 		pushEntry(msg, t, undefined, context);
 	});
 }

--- a/tests/prepack-package-contents.mjs
+++ b/tests/prepack-package-contents.mjs
@@ -67,6 +67,7 @@ try {
       {
         cwd: packageDir,
         encoding: 'utf8',
+        shell: process.platform === 'win32',
       },
     );
     assert.equal(


### PR DESCRIPTION
### Summary
A collection of small standalone fixes across packaging, subprocess execution, plugin typing, and Windows testing.

### Changes
* **Subprocess security:** Replaced `execSync` with parameterized `execFileSync` in `install-plugin-helpers.ts` to avoid shell interpolation on Windows/WSL.
* **Package size:** Added a `files` array in `packages/core/package.json` to exclude tests and map files from the published npm package.
* **Plugin typing:** Fixed `LogService.MessageOut` callback typing in `RuntimeLogBuffer.ts` so `rbxtsc` builds without type errors.
* **Gitignore:** Added `*.rbxm` and `.*.lock` to `studio-plugin/.gitignore`.
* **Windows tests:** Added `shell: process.platform === 'win32'` in `prepack-package-contents.mjs`.

### Validation
* `npm run compile:plugin` (rbxtsc passed cleanly)
* `npm run typecheck` (0 errors)
* `npm run build` (clean build across all packages)
* `npm test` (all 20 Jest suites, 292 tests passed)
* `npm run test:package-contents` (passed)
* `npm run test:runner` (passed)
* `npm run test:port-isolation` (passed)