### PR TITLE
fix: preserve text projection fallback for standard MCP clients

### DIFF
--- a/packages/core/src/__tests__/mcp-runtime.test.ts
+++ b/packages/core/src/__tests__/mcp-runtime.test.ts
@@ -52,7 +52,7 @@ function collectPropertySchemas(
 }
 
 describe('MCP v2 tool runtime', () => {
-  test('projects JSON once for modern clients and preserves media', () => {
+  test('keeps a compact JSON text fallback for modern clients and preserves media', () => {
     const result = normalizeToolResult({
       content: [
         {
@@ -70,7 +70,32 @@ describe('MCP v2 tool runtime', () => {
 
     expect(result.structuredContent).toEqual({ success: true, value: 42 });
     expect(result.content).toEqual([
+      { type: 'text', text: JSON.stringify({ success: true, value: 42 }) },
       { type: 'image', data: 'aW1hZ2U=', mimeType: 'image/png' },
+    ]);
+  });
+
+  test('allows verified modern clients to opt into structured-only results', () => {
+    const result = normalizeToolResult({
+      content: [{ type: 'text', text: JSON.stringify({ value: 42 }) }],
+    }, 'modern', 'structured');
+
+    expect(result.structuredContent).toEqual({ value: 42 });
+    expect(result.content).toEqual([]);
+  });
+
+  test('keeps unrelated JSON text blocks while replacing the structured projection', () => {
+    const result = normalizeToolResult({
+      structuredContent: { success: true },
+      content: [
+        { type: 'text', text: JSON.stringify({ success: true }) },
+        { type: 'text', text: JSON.stringify({ note: 'separate JSON document' }) },
+      ],
+    }, 'modern');
+
+    expect(result.content).toEqual([
+      { type: 'text', text: JSON.stringify({ success: true }) },
+      { type: 'text', text: JSON.stringify({ note: 'separate JSON document' }) },
     ]);
   });
 
@@ -83,6 +108,19 @@ describe('MCP v2 tool runtime', () => {
     expect(result.content).toEqual([
       { type: 'text', text: JSON.stringify({ value: 42 }) },
     ]);
+  });
+
+  test('turns an unexpected empty tool response into a visible error', () => {
+    const result = normalizeToolResult({ content: [] }, 'modern');
+
+    expect(result).toEqual({
+      content: [{
+        type: 'text',
+        text: JSON.stringify({ error: 'empty_tool_result', message: 'Tool returned no content.' }),
+      }],
+      structuredContent: { error: 'empty_tool_result', message: 'Tool returned no content.' },
+      isError: true,
+    });
   });
 
   test('keeps the catalog within the 3.0 token budget', () => {
@@ -293,7 +331,7 @@ describe('MCP v2 tool runtime', () => {
 
   test.each([
     ['legacy', undefined, true],
-    ['2026-07-28', { mode: { pin: '2026-07-28' as const } }, false],
+    ['2026-07-28', { mode: { pin: '2026-07-28' as const } }, true],
   ])('serves %s clients on the shared HTTP endpoint', async (_label, versionNegotiation, keepsTextProjection) => {
     const definition = TOOL_DEFINITIONS.find((tool) => tool.name === 'get_place_info')!;
     const getPlaceInfo = jest.fn(async () => ({
@@ -330,7 +368,7 @@ describe('MCP v2 tool runtime', () => {
       expect(getPlaceInfo).toHaveBeenCalled();
     } finally {
       await client.close().catch(() => {});
-      await (app as any).closeMcpHandler?.();
+      await (app as typeof app & { closeMcpHandler?: () => Promise<void> | void }).closeMcpHandler?.();
       await new Promise<void>((resolve) => httpServer.close(() => resolve()));
     }
   });

--- a/packages/core/src/mcp-runtime.ts
+++ b/packages/core/src/mcp-runtime.ts
@@ -14,6 +14,7 @@ import type { RobloxStudioTools } from './tools/index.js';
 import type { ToolDefinition } from './tools/definitions.js';
 
 export type ProtocolEra = McpRequestContext['era'];
+export type ToolResultMode = 'compatible' | 'structured';
 
 export interface McpRuntimeConfig {
   name: string;
@@ -128,36 +129,82 @@ function parseJsonObject(text: string): Record<string, unknown> | undefined {
 }
 
 /**
- * Converts the historic JSON-in-text result shape into the lean 2026 MCP shape.
- * Modern clients receive JSON once in structuredContent; legacy clients keep the
- * text projection required by older SDKs. Human-readable text and media survive.
+ * Defaults to a standards-compatible text fallback so clients that do not
+ * surface structuredContent never render an apparently empty tool result.
+ * Set ROBLOX_STUDIO_MCP_RESULT_MODE=structured only for clients verified to
+ * consume structuredContent directly.
  */
-export function normalizeToolResult(raw: unknown, era: ProtocolEra): CallToolResult {
+export function resolveToolResultMode(
+  value = process.env.ROBLOX_STUDIO_MCP_RESULT_MODE,
+): ToolResultMode {
+  return value?.trim().toLowerCase() === 'structured'
+    ? 'structured'
+    : 'compatible';
+}
+
+/**
+ * Converts the historic JSON-in-text result shape into structured MCP output.
+ * By default, each structured result also has one compact JSON text projection.
+ * That fallback keeps results visible in clients that do not surface
+ * structuredContent, while preserving human-readable text and media.
+ */
+export function normalizeToolResult(
+  raw: unknown,
+  era: ProtocolEra,
+  resultMode = resolveToolResultMode(),
+): CallToolResult {
   const result = (raw && typeof raw === 'object' ? raw : {}) as ToolResultLike;
   const originalContent = Array.isArray(result.content) ? result.content : [];
   let structured = asStructuredObject(result.structuredContent);
-  const jsonTextIndex = originalContent.findIndex((block) =>
-    block.type === 'text' && typeof block.text === 'string' && !!parseJsonObject(block.text));
+  let jsonTextIndex = -1;
 
   if (!structured) {
-    if (jsonTextIndex >= 0) {
-      structured = parseJsonObject((originalContent[jsonTextIndex] as { type: 'text'; text: string }).text);
+    for (const [index, block] of originalContent.entries()) {
+      if (block.type !== 'text' || typeof block.text !== 'string') continue;
+      const parsed = parseJsonObject(block.text);
+      if (!parsed) continue;
+      structured = parsed;
+      jsonTextIndex = index;
+      break;
+    }
+  } else {
+    const serializedStructured = JSON.stringify(structured);
+    for (const [index, block] of originalContent.entries()) {
+      if (block.type !== 'text' || typeof block.text !== 'string') continue;
+      const parsed = parseJsonObject(block.text);
+      if (parsed && JSON.stringify(parsed) === serializedStructured) {
+        jsonTextIndex = index;
+        break;
+      }
     }
   }
 
   if (!structured) {
+    if (originalContent.length === 0) {
+      const emptyResult = {
+        error: 'empty_tool_result',
+        message: 'Tool returned no content.',
+      };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(emptyResult) }],
+        structuredContent: emptyResult,
+        isError: true,
+      };
+    }
     return {
       content: originalContent as CallToolResult['content'],
       ...(result.isError ? { isError: true } : {}),
     };
   }
 
-  const content = era === 'modern'
-    ? originalContent.filter((_, index) => index !== jsonTextIndex)
-    : [
+  const nonProjectionContent = originalContent.filter((_, index) => index !== jsonTextIndex);
+  const includeTextProjection = era === 'legacy' || resultMode === 'compatible';
+  const content = includeTextProjection
+    ? [
         { type: 'text' as const, text: JSON.stringify(structured) },
-        ...originalContent.filter((_, index) => index !== jsonTextIndex),
-      ];
+        ...nonProjectionContent,
+      ]
+    : nonProjectionContent;
 
   return {
     content: content as CallToolResult['content'],


### PR DESCRIPTION
### Summary
Ensures tool results render correctly in standard MCP clients (like Google Antigravity and older SDKs) that expect output in `content[].text` rather than solely in `structuredContent`.

### Changes
* Preserved a compact JSON text fallback in `content` alongside `structuredContent` by default.
* Added `ROBLOX_STUDIO_MCP_RESULT_MODE=structured` so clients that explicitly support structured content can opt into text-free output.
* Surfaced empty tool responses (`content: []`) as an explicit structured error instead of blank output.
* Added unit tests covering text projection, structured-only mode, and empty result handling.

### Validation
* `npm run typecheck` (0 errors)
* `npm run build` (clean build)
* `npm test -w packages/core` (all 20 Jest suites, 295 tests passed, including 3 new test cases)