### PR TITLE
Feat/execute luau undo

### DIFF
--- a/studio-plugin/src/modules/RuntimeLogBuffer.ts
+++ b/studio-plugin/src/modules/RuntimeLogBuffer.ts
@@ -142,7 +142,7 @@ function install(): void {
 	// Seed from per-DataModel LogHistory so get_runtime_logs can still see them;
 	// edit history is bounded to the current Studio process above.
 	seedRuntimeHistory();
-	LogService.MessageOut.Connect((msg, t, context?: Record<string, unknown>) => {
+	LogService.MessageOut.Connect((msg, t, context?: any) => {
 		pushEntry(msg, t, undefined, context);
 	});
 }

--- a/studio-plugin/src/modules/handlers/MetadataHandlers.ts
+++ b/studio-plugin/src/modules/handlers/MetadataHandlers.ts
@@ -1,5 +1,6 @@
 import Utils from "../Utils";
 import LuauExec from "../LuauExec";
+import Recording from "../Recording";
 
 const Selection = game.GetService("Selection");
 
@@ -243,11 +244,20 @@ function focusViewport(requestData: Record<string, unknown>) {
 function executeLuau(requestData: Record<string, unknown>) {
 	const code = requestData.code as string;
 	if (!code || code === "") return { error: "Code is required" };
+
+	const recordingId = Recording.beginRecording("MCP execute_luau");
+	
 	// All wrapping, print/warn capture, loadstring fallback, JSON-encoding
 	// of table returns, and parse-error recovery live in LuauExec so the
 	// edit/server (this handler) and the play-client (ClientBroker) take
 	// the same code path and produce identical output shapes.
-	return LuauExec.execute(code);
+	const result = LuauExec.execute(code);
+	
+	if (recordingId !== undefined) {
+		Recording.finishRecording(recordingId, result.success);
+	}
+	
+	return result;
 }
 
 export = {


### PR DESCRIPTION
### Summary
Groups all DataModel mutations from a single `execute_luau` call into one `ChangeHistoryService` recording, enabling full rollback with a single Ctrl+Z in Roblox Studio.

### Changes
* Wrapped `LuauExec.execute` inside `Recording.beginRecording("MCP execute_luau")` and `Recording.finishRecording`.
* Ensured graceful fallback in environments where `ChangeHistoryService` is inactive.
* Fixed `LogService.MessageOut` typing in `RuntimeLogBuffer.ts` so `rbxtsc` compiles cleanly.

### Validation
* `npm run compile:plugin` (rbxtsc passed cleanly)