### PR TITLE
fix: stop registry lock retries retaining Jest workers

### DIFF
--- a/packages/core/src/__tests__/managed-instance-registry.test.ts
+++ b/packages/core/src/__tests__/managed-instance-registry.test.ts
@@ -1,0 +1,59 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { setTimeout as waitForTimeout } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
+
+describe('ManagedInstanceRegistry lock lifecycle', () => {
+  test('a lock retry does not keep an otherwise idle Node process alive', async () => {
+    const registryDir = await fs.mkdtemp(path.join(os.tmpdir(), 'robloxstudio-mcp-lock-test-'));
+    const lockDir = path.join(registryDir, '.lock');
+    await fs.mkdir(lockDir);
+    await fs.writeFile(path.join(lockDir, 'owner.json'), JSON.stringify({
+      pid: process.pid,
+      token: 'active-parent-test-lock',
+      createdAt: Date.now(),
+    }));
+
+    const registryModuleUrl = pathToFileURL(path.resolve(process.cwd(), 'src/managed-instance-registry.ts')).href;
+    // This subprocess loads the source module at runtime to exercise real process-exit behavior.
+    const child = spawn(process.execPath, [
+      '--import',
+      'tsx',
+      '--input-type=module',
+      '--eval',
+      [
+        'const { ManagedInstanceRegistry } = await import(process.env.TEST_REGISTRY_MODULE_URL);',
+        'void new ManagedInstanceRegistry(process.env.TEST_REGISTRY_DIR).listOpen({ currentBootId: "child-test" });',
+      ].join('\n'),
+    ], {
+      env: {
+        ...process.env,
+        TEST_REGISTRY_DIR: registryDir,
+        TEST_REGISTRY_MODULE_URL: registryModuleUrl,
+      },
+      stdio: 'ignore',
+    });
+    const exited = once(child, 'exit').then(([code, signal]) => ({
+      kind: 'exit' as const,
+      code,
+      signal,
+    }));
+
+    try {
+      const outcome = await Promise.race([
+        exited,
+        waitForTimeout(5000, { kind: 'timeout' as const }, { ref: false }),
+      ]);
+      expect(outcome).toEqual({ kind: 'exit', code: 0, signal: null });
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill();
+        await exited;
+      }
+      await fs.rm(registryDir, { recursive: true, force: true });
+    }
+  }, 10_000);
+});

--- a/packages/core/src/managed-instance-registry.ts
+++ b/packages/core/src/managed-instance-registry.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises';
 import { randomUUID } from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
+import { setTimeout as delayTimer } from 'node:timers/promises';
 
 const REGISTRY_VERSION = 1;
 const LOCK_STALE_MS = 10000;
@@ -98,7 +99,7 @@ export function defaultManagedInstanceRegistryDir(): string {
 }
 
 function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return delayTimer(ms, undefined, { ref: false });
 }
 
 function ymd(timestamp: number): string {


### PR DESCRIPTION
## Summary
- make managed-instance registry lock retries use an unreferenced timer
- add a subprocess regression that holds the registry lock and proves an otherwise-idle Node process can exit
- keep the replacement focused on the timer allocation stack that remained active at Jest worker teardown

## Root cause
The forced-worker warning was reproducible, but the active handles were not primarily the server/coordinator timers targeted by the superseded PR. Resource tracing identified the retained path as:

`ManagedInstanceRegistry.withLock` → lock retry delay → `StudioInstanceManager.pendingLaunches` → managed connection association.

The 25 ms retry timer was referenced, so background registry association work kept a Jest worker alive until Jest force-exited it. The retry now uses `node:timers/promises` with `ref: false`.

## Regression coverage
The new test starts a child Node process while another live process owns the registry lock. With a referenced retry timer, the child remains alive and the test times out after five seconds. With this change, the child exits normally.

## Validation
- regression control with `ref: true`: failed after 5 seconds with `{ kind: "timeout" }`
- focused regression with `ref: false`: passed
- `npm test -w packages/core` repeated three times: 293/293 passed with no forced-worker warning
- `npm test`: passed with no forced-worker warning
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Closes #49