### PR TITLE
perf: omit empty collections at response producers

### DIFF
--- a/packages/core/src/__tests__/mcp-runtime.test.ts
+++ b/packages/core/src/__tests__/mcp-runtime.test.ts
@@ -74,6 +74,27 @@ describe('MCP v2 tool runtime', () => {
     ]);
   });
 
+  test('preserves public empty collections and null values', () => {
+    const result = normalizeToolResult({
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          children: [],
+          attributes: [],
+          process_running: null,
+          nested: { warnings: [] },
+        }),
+      }],
+    }, 'modern');
+
+    expect(result.structuredContent).toEqual({
+      children: [],
+      attributes: [],
+      process_running: null,
+      nested: { warnings: [] },
+    });
+  });
+
   test('keeps one JSON text projection for legacy clients', () => {
     const result = normalizeToolResult({
       content: [{ type: 'text', text: JSON.stringify({ value: 42 }) }],

--- a/studio-plugin/src/modules/handlers/MetadataHandlers.ts
+++ b/studio-plugin/src/modules/handlers/MetadataHandlers.ts
@@ -50,7 +50,9 @@ function getAttributes(requestData: Record<string, unknown>) {
 			count++;
 		}
 
-		return { instancePath, attributes: serializedAttributes, count };
+		const response: Record<string, unknown> = { instancePath, count };
+		if (count > 0) response.attributes = serializedAttributes;
+		return response;
 	});
 
 	if (success) return result;

--- a/studio-plugin/src/modules/handlers/QueryHandlers.ts
+++ b/studio-plugin/src/modules/handlers/QueryHandlers.ts
@@ -415,7 +415,6 @@ function getProjectStructure(requestData: Record<string, unknown>) {
 			name: instance.Name,
 			className: instance.ClassName,
 			path: getInstancePath(instance),
-			children: [] as Record<string, unknown>[],
 		};
 
 		if (instance.IsA("LuaSourceContainer")) {
@@ -446,7 +445,7 @@ function getProjectStructure(requestData: Record<string, unknown>) {
 			);
 		}
 
-		const nodeChildren = node.children as Record<string, unknown>[];
+		const nodeChildren: Record<string, unknown>[] = [];
 		const childCount = children.size();
 		if (childCount > 20 && depth < maxDepth) {
 			const classGroups = new Map<string, Instance[]>();
@@ -484,6 +483,9 @@ function getProjectStructure(requestData: Record<string, unknown>) {
 			for (const child of children) {
 				nodeChildren.push(getStructure(child, depth + 1));
 			}
+		}
+		if (nodeChildren.size() > 0) {
+			node.children = nodeChildren;
 		}
 
 		return node;

--- a/tests/studio-tooling-smoke.mjs
+++ b/tests/studio-tooling-smoke.mjs
@@ -257,6 +257,36 @@ return true
   };
 
   try {
+    const fullTree = await client.callTool('get_project_structure', {
+      path: folderPath,
+      maxDepth: 5,
+      instance_id: instanceId,
+    });
+    assertNoError(fullTree, 'get_project_structure returns smoke fixture');
+    assert(Array.isArray(fullTree.children), 'get_project_structure preserves populated children');
+    const partNode = fullTree.children.find((child) => child.name === 'SmokePart');
+    const scriptNode = fullTree.children.find((child) => child.name === 'SmokeScript');
+    const nestedNode = scriptNode?.children?.find((child) => child.name === 'NestedModule');
+    assert(partNode && !Object.hasOwn(partNode, 'children'), 'get_project_structure omits children from a leaf');
+    assert(Array.isArray(scriptNode?.children), 'get_project_structure preserves a branch children array');
+    assert(
+      nestedNode && !Object.hasOwn(nestedNode, 'children'),
+      'get_project_structure omits children from a nested leaf',
+    );
+
+    const truncatedTree = await client.callTool('get_project_structure', {
+      path: folderPath,
+      maxDepth: 0,
+      instance_id: instanceId,
+    });
+    const truncatedPart = truncatedTree.children?.find((child) => child.name === 'SmokePart');
+    assert(
+      truncatedPart?.hasMore === true &&
+        truncatedPart.childCount === 0 &&
+        !Object.hasOwn(truncatedPart, 'children'),
+      'get_project_structure preserves max-depth markers when children are omitted',
+    );
+
     const setProp = await client.callTool('set_properties', {
       instancePath: partPath,
       properties: { Transparency: 0.25 },
@@ -276,6 +306,15 @@ return true
       instance_id: instanceId,
     });
     assert(attrs.attributes?.SmokeAttr?.value === 'ok', 'get_attributes returns smoke attribute');
+
+    const emptyAttrs = await client.callTool('get_attributes', {
+      instancePath: scriptPath,
+      instance_id: instanceId,
+    });
+    assert(
+      emptyAttrs.count === 0 && !Object.hasOwn(emptyAttrs, 'attributes'),
+      'get_attributes omits an empty attributes collection while preserving count',
+    );
 
     const tag = await client.callTool('execute_luau', {
       target: 'edit',


### PR DESCRIPTION
## Summary

- omit `children` only from fully traversed leaf nodes produced by `get_project_structure`
- omit `attributes` only when `get_attributes` reports `count: 0`
- preserve populated collections, max-depth markers, arbitrary empty arrays, and meaningful `null` values

## Why

The redundant collections reported in #50 are reproducible, but the generic compaction proposed in #42 would also rewrite unrelated tool results and remove meaningful nulls such as `process_running: null`.

This moves the optimization to the handlers that own the relevant response semantics. `search_objects` and the generic MCP result normalizer remain unchanged.

This supersedes #42. Thanks @ProudBraveGladiator for identifying the serialization overhead.

## Compatibility

- populated hierarchy branches still include `children`
- depth-truncated nodes retain `hasMore`, `childCount`, and their explanatory note
- populated attribute maps remain unchanged
- arbitrary `execute_luau` result shapes remain untouched
- public empty collections and nulls remain preserved by `normalizeToolResult`

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run test:studio:smoke`

Closes #50