### PR TITLE
Prevent screenshot payloads from exceeding HTTP and MCP limits

### DIFF
--- a/packages/core/src/__tests__/smoke.test.ts
+++ b/packages/core/src/__tests__/smoke.test.ts
@@ -4176,12 +4176,17 @@ describe('Smoke', () => {
     const tools = new RobloxStudioTools(bridge);
     bridge.registerInstance(READY);
 
-    const noiseSide = 1400;
+    const noiseSide = 2000;
     const noise = Buffer.alloc(noiseSide * noiseSide * 4);
     let seed = 0x12345678;
-    for (let i = 0; i < noise.length; i++) {
+    for (let i = 0; i < noise.length; i += 4) {
       seed = (seed * 1664525 + 1013904223) >>> 0;
-      noise[i] = seed & 0xff;
+      noise[i] = seed >>> 24;
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      noise[i + 1] = seed >>> 24;
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      noise[i + 2] = seed >>> 24;
+      noise[i + 3] = 255;
     }
     const noiseB64 = noise.toString('base64');
 

--- a/packages/core/src/__tests__/smoke.test.ts
+++ b/packages/core/src/__tests__/smoke.test.ts
@@ -4143,4 +4143,93 @@ describe('Smoke', () => {
     });
     expect(result.content.some((item) => item.type === 'image')).toBe(true);
   });
+
+  test('capture_screenshot reports the coordinate multiplier when Studio downscales the capture', async () => {
+    const bridge = new BridgeService();
+    const tools = new RobloxStudioTools(bridge);
+    bridge.registerInstance(READY);
+
+    const resultPromise = tools.captureScreenshot('place:test', 'jpeg', 80);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const capturePending = bridge.getPendingRequest('place:test', 'edit');
+    expect(capturePending?.request).toMatchObject({ endpoint: '/api/capture-screenshot' });
+    bridge.resolveRequest(capturePending!.requestId, {
+      width: 3,
+      height: 1,
+      nativeWidth: 4,
+      nativeHeight: 2,
+      data: Buffer.alloc(12, 255).toString('base64'),
+    });
+
+    const result = await resultPromise;
+    const firstContent = result.content[0];
+    if (firstContent.type !== 'text' || firstContent.text === undefined) throw new Error('Expected screenshot metadata text first');
+    const meta = JSON.parse(firstContent.text);
+    expect(meta).toMatchObject({ width: 3, height: 1, format: 'jpeg' });
+    expect(meta.message).toContain('downscaled from the 4x2 viewport');
+    expect(meta.message).toContain('multiply x read off this image by 1.3333 and y by 2.0000');
+  });
+
+  test('capture_device_matrix keeps the total inline image payload within the aggregate budget', async () => {
+    const bridge = new BridgeService();
+    const tools = new RobloxStudioTools(bridge);
+    bridge.registerInstance(READY);
+
+    const noiseSide = 1400;
+    const noise = Buffer.alloc(noiseSide * noiseSide * 4);
+    let seed = 0x12345678;
+    for (let i = 0; i < noise.length; i++) {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      noise[i] = seed & 0xff;
+    }
+    const noiseB64 = noise.toString('base64');
+
+    const resultPromise = tools.captureDeviceMatrix(
+      [{ label: 'a', deviceId: 'iphone_XR' }, { label: 'b', deviceId: 'ipad' }],
+      'edit',
+      'jpeg',
+      100,
+      0,
+      false,
+      'place:test',
+    );
+
+    const snapshotPending = bridge.getPendingRequest('place:test', 'edit');
+    bridge.resolveRequest(snapshotPending!.requestId, {
+      success: true,
+      returnValue: JSON.stringify({ activeDeviceId: 'default', isSimulating: false }),
+    });
+
+    for (const label of ['a', 'b']) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const setPending = bridge.getPendingRequest('place:test', 'edit');
+      bridge.resolveRequest(setPending!.requestId, {
+        success: true,
+        returnValue: JSON.stringify({
+          success: true,
+          applied: { deviceId: label },
+          before: { activeDeviceId: 'default', isSimulating: false },
+          after: { activeDeviceId: label, isSimulating: true },
+        }),
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const capturePending = bridge.getPendingRequest('place:test', 'edit');
+      expect(capturePending?.request).toMatchObject({ endpoint: '/api/capture-screenshot' });
+      bridge.resolveRequest(capturePending!.requestId, {
+        width: noiseSide,
+        height: noiseSide,
+        data: noiseB64,
+      });
+    }
+
+    const result = await resultPromise;
+    const images = result.content.filter(
+      (item): item is { type: 'image'; data: string; mimeType: string } => item.type === 'image',
+    );
+    expect(images).toHaveLength(2);
+    const totalBytes = images.reduce((sum, item) => sum + Math.ceil((item.data.length * 3) / 4), 0);
+    expect(totalBytes).toBeLessThanOrEqual(8_000_000);
+  });
 });

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -29,6 +29,8 @@ type RawImageCaptureResponse = {
   error?: string;
   width?: number;
   height?: number;
+  nativeWidth?: number;
+  nativeHeight?: number;
   data?: string;
   instancePath?: string;
   instanceName?: string;
@@ -73,6 +75,7 @@ type GenerateModelImage =
   { kind: 'asset'; asset_id: number };
 
 const MAX_INLINE_IMAGE_BYTES = 6_000_000;
+const MAX_MATRIX_IMAGE_BYTES = 8_000_000;
 const DEFAULT_ASSET_AUDIO_PREVIEWS = 3;
 const MAX_ASSET_AUDIO_PREVIEWS = 5;
 const MAX_INLINE_AUDIO_PREVIEW_BYTES = 3_000_000;
@@ -2256,6 +2259,7 @@ export class RobloxStudioTools {
     const entrySummaries = summary.entries as Array<Record<string, unknown>>;
     const content: ToolContent[] = [];
     const failures: string[] = [];
+    let imageBudget = MAX_MATRIX_IMAGE_BYTES;
 
     try {
       for (let i = 0; i < matrixEntries.length; i++) {
@@ -2280,8 +2284,10 @@ export class RobloxStudioTools {
           entrySummary.applied = applied;
           if (settleMs > 0) await sleep(settleMs);
 
-          const capture = await this._captureViewportImage(resolved.instanceId, resolved.role, format, quality);
+          const entryBudget = Math.max(1, Math.floor(imageBudget / (matrixEntries.length - i)));
+          const capture = await this._captureViewportImage(resolved.instanceId, resolved.role, format, quality, entryBudget);
           if (capture.success) {
+            imageBudget -= Math.ceil((capture.data.length * 3) / 4);
             entrySummary.screenshot = {
               width: capture.width,
               height: capture.height,
@@ -4707,6 +4713,7 @@ export class RobloxStudioTools {
     targetRole: string,
     format?: string,
     quality?: number,
+    maxBytes: number = MAX_INLINE_IMAGE_BYTES,
   ): Promise<EncodedViewportCapture> {
     let response: RawImageCaptureResponse;
     if (targetRole.startsWith('client-')) {
@@ -4766,32 +4773,47 @@ export class RobloxStudioTools {
     let usedQ = q;
     let note = '';
 
-    if (buffer.length > MAX_INLINE_IMAGE_BYTES) {
+    if (buffer.length > maxBytes) {
       if (fmt === 'png') {
         const mb = (buffer.length / 1048576).toFixed(1);
         return {
           success: false,
           error:
-            `PNG screenshot is ${mb}MB, over the ~${(MAX_INLINE_IMAGE_BYTES / 1048576).toFixed(0)}MB inline image limit. ` +
+            `PNG screenshot is ${mb}MB, over the ~${(maxBytes / 1048576).toFixed(1)}MB inline image limit. ` +
             `Use the default jpeg format (optionally with a "quality" value) or make the Studio window smaller for a lossless capture.`,
         };
       }
-      while (buffer.length > MAX_INLINE_IMAGE_BYTES && usedQ > 25) {
+      while (buffer.length > maxBytes && usedQ > 25) {
         usedQ = Math.max(25, usedQ - 20);
         buffer = encodeImageFromRgbaResponse(response, 'jpeg', usedQ).buffer;
+      }
+      if (buffer.length > maxBytes) {
+        return {
+          success: false,
+          error:
+            `JPEG screenshot is still ${(buffer.length / 1048576).toFixed(1)}MB at q${usedQ}, over the ` +
+            `${(maxBytes / 1048576).toFixed(1)}MB inline budget. Make the Studio window smaller or capture fewer images per call.`,
+        };
       }
       note = ` — auto-reduced to q${usedQ} to fit the inline size limit; enlarge the Studio window or capture a smaller region for finer detail`;
     }
 
     // Explicit coordinate contract: the image is returned at native viewport
-    // resolution and is never downscaled, so its pixel grid IS the coordinate
-    // space simulate_mouse_input expects. Stating the dimensions removes any
-    // ambiguity about what (x, y) mean.
-
+    // resolution whenever it fits the transport cap, so its pixel grid IS the
+    // coordinate space simulate_mouse_input expects. Oversized captures are
+    // downscaled in Studio before transfer; the message then tells the caller
+    // how to map image coordinates back to viewport coordinates.
+    const nativeW = response.nativeWidth ?? w;
+    const nativeH = response.nativeHeight ?? h;
     const message =
-      `Screenshot ${w}x${h}px (${fmt}${fmt === 'jpeg' ? ` q${usedQ}` : ''})${note}. ` +
-      `For simulate_mouse_input, x/y are pixel coordinates in this exact image with (0,0) at the ` +
-      `top-left; it is not downscaled, so use coordinates as you read them off the image.`;
+      nativeW !== w || nativeH !== h
+        ? `Screenshot ${w}x${h}px (${fmt}${fmt === 'jpeg' ? ` q${usedQ}` : ''})${note}, downscaled from the ` +
+          `${nativeW}x${nativeH} viewport to fit transport limits. For simulate_mouse_input, multiply x read off ` +
+          `this image by ${(nativeW / w).toFixed(4)} and y by ${(nativeH / h).toFixed(4)} to get viewport pixel ` +
+          `coordinates ((0,0) at the top-left).`
+        : `Screenshot ${w}x${h}px (${fmt}${fmt === 'jpeg' ? ` q${usedQ}` : ''})${note}. ` +
+          `For simulate_mouse_input, x/y are pixel coordinates in this exact image with (0,0) at the ` +
+          `top-left; it is not downscaled, so use coordinates as you read them off the image.`;
 
     return {
       success: true,
@@ -4823,6 +4845,7 @@ export class RobloxStudioTools {
             format: capture.format,
             mimeType: capture.mimeType,
             ...(capture.quality === undefined ? {} : { quality: capture.quality }),
+            message: capture.message,
           }),
         },
         {

--- a/studio-plugin/src/modules/handlers/CaptureHandlers.ts
+++ b/studio-plugin/src/modules/handlers/CaptureHandlers.ts
@@ -4,6 +4,8 @@ const CaptureService = game.GetService("CaptureService");
 const AssetService = game.GetService("AssetService");
 
 const MAX_TILE_SIZE = 1024;
+const MAX_RAW_PIXEL_BYTES = 36 * 1024 * 1024;
+const MAX_CREATED_IMAGE_DIM = 2048;
 const BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 const PAD_BYTE = string.byte("=")[0];
 
@@ -119,16 +121,43 @@ function readContentToBase64(contentId: string): unknown {
 		};
 	}
 
-	const editableImage = editableResult as EditableImage;
-	const imgSize = editableImage.Size;
-	const w = math.floor(imgSize.X);
-	const h = math.floor(imgSize.Y);
+	let sourceImage = editableResult as EditableImage;
+	const imgSize = sourceImage.Size;
+	const nativeW = math.floor(imgSize.X);
+	const nativeH = math.floor(imgSize.Y);
+	let w = nativeW;
+	let h = nativeH;
+
+	if (nativeW * nativeH * 4 > MAX_RAW_PIXEL_BYTES) {
+		const scale = math.min(
+			math.sqrt(MAX_RAW_PIXEL_BYTES / (nativeW * nativeH * 4)),
+			MAX_CREATED_IMAGE_DIM / math.max(nativeW, nativeH),
+		);
+		w = math.max(1, math.floor(nativeW * scale));
+		h = math.max(1, math.floor(nativeH * scale));
+		const [scaleOk, scaledResult] = pcall(() => {
+			const target = AssetService.CreateEditableImage({ Size: new Vector2(w, h) });
+			target.DrawImageTransformed(new Vector2(0, 0), new Vector2(w / nativeW, h / nativeH), 0, sourceImage, {
+				CombineType: Enum.ImageCombineType.AlphaBlend,
+				SamplingMode: Enum.ResamplerMode.Default,
+				PivotPoint: new Vector2(0, 0),
+			});
+			return target;
+		});
+		sourceImage.Destroy();
+		if (!scaleOk) {
+			return {
+				error: `Screenshot is ${nativeW}x${nativeH} (too large to transfer raw) and downscaling failed: ${tostring(scaledResult)}`,
+			};
+		}
+		sourceImage = scaledResult as EditableImage;
+	}
 
 	const [readOk, pixelBuffer] = pcall(() => {
-		return readPixelsTiled(editableImage, w, h);
+		return readPixelsTiled(sourceImage, w, h);
 	});
 
-	editableImage.Destroy();
+	sourceImage.Destroy();
 
 	if (!readOk) {
 		return { error: `Failed to read pixel data: ${tostring(pixelBuffer)}` };
@@ -136,7 +165,7 @@ function readContentToBase64(contentId: string): unknown {
 
 	const base64Data = encodeBase64(pixelBuffer as buffer);
 
-	return { success: true, width: w, height: h, data: base64Data };
+	return { success: true, width: w, height: h, data: base64Data, nativeWidth: nativeW, nativeHeight: nativeH };
 }
 
 // Edit-mode single shot: capture and read back in the same (edit) context.


### PR DESCRIPTION
Fixes #60.

- Studio posted raw RGBA with no size check, so a 5K capture (75 MB as base64) blew the 50 MB response limit. The plugin now downscales big captures in the engine first, capped at 2048 pixels per side (measured: 2048 works, 2049 errors).
- Downscaled screenshots report the native viewport size and the x/y multipliers for mouse input coordinates.
- Device matrix entries now share one 8 MB inline budget instead of 6 MB each, and a capture that cannot fit even at minimum JPEG quality returns an error instead of a payload that kills the connection.

Verified live in Studio (dimension limit, downscale pipeline, corner pixel fill). Three new tests; all 316 pass; plugin compiles.