### PR TITLE
Preserve plugins until installation succeeds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7043,6 +7043,18 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -8115,6 +8127,12 @@
         }
       }
     },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -8187,7 +8205,8 @@
       "name": "@chrrxs/robloxstudio-mcp-core",
       "version": "3.0.2",
       "dependencies": {
-        "fzstd": "^0.1.1"
+        "fzstd": "^0.1.1",
+        "saxes": "^6.0.0"
       },
       "devDependencies": {
         "@modelcontextprotocol/client": "^2.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "fzstd": "^0.1.1"
+    "fzstd": "^0.1.1",
+    "saxes": "^6.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/core/src/__tests__/plugin-installation.test.ts
+++ b/packages/core/src/__tests__/plugin-installation.test.ts
@@ -1,4 +1,10 @@
-import { configurePluginAssetForPort } from '../install-plugin-helpers.js';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  configurePluginAssetForPort,
+  installPluginAsset,
+} from '../install-plugin-helpers.js';
 
 describe('Studio plugin installation', () => {
   const source = Buffer.from([
@@ -8,6 +14,47 @@ describe('Studio plugin installation', () => {
     'const SETTING_KEY_PREFIX = "MCP_LAST_SUCCESSFUL_SERVER_URL_";',
     'const UNRELATED_ID = 58741;',
   ].join('\n'));
+  const expectedPluginVersion = '1.2.3';
+  const installLockName = '.robloxstudio-mcp-plugin-install.lock';
+
+  const pluginAsset = ({
+    version = expectedPluginVersion,
+    variant = 'main',
+    includeDefaultConnection = true,
+  }: {
+    version?: string;
+    variant?: string;
+    includeDefaultConnection?: boolean;
+  } = {}): Buffer => Buffer.from([
+    '<?xml version="1.0" encoding="utf-8"?>',
+    '<roblox version="4">',
+    '<Item class="Script"><Properties><string name="Source"><![CDATA[',
+    `local CURRENT_VERSION = "${version}";`,
+    `local PLUGIN_VARIANT = "${variant}";`,
+    ...(includeDefaultConnection
+      ? [
+          'local BASE_PORT = 58741;',
+          'local DEFAULT_MCP_URL = "http://localhost:58741";',
+          'local GLOBAL_SETTING_KEY = "MCP_LAST_SUCCESSFUL_SERVER_URL_GLOBAL_V1";',
+          'local SETTING_KEY_PREFIX = "MCP_LAST_SUCCESSFUL_SERVER_URL_";',
+        ]
+      : []),
+    ']]></string></Properties></Item>',
+    '</roblox>',
+  ].join('\n'));
+
+  const tempDirectories: string[] = [];
+  const createPluginsFolder = (): string => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'robloxstudio-mcp-plugin-install-'));
+    tempDirectories.push(directory);
+    return directory;
+  };
+
+  afterEach(() => {
+    for (const directory of tempDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
 
   test('leaves the release artifact byte-for-byte unchanged on the default port', () => {
     const previousPort = process.env.ROBLOX_STUDIO_PORT;
@@ -38,5 +85,156 @@ describe('Studio plugin installation', () => {
   test('fails rather than silently installing an artifact without the expected defaults', () => {
     expect(() => configurePluginAssetForPort(Buffer.from('unrelated plugin'), '43123'))
       .toThrow(/default port/i);
+  });
+
+  test('preserves both installed variants when configuration fails', () => {
+    const pluginsFolder = createPluginsFolder();
+    const target = path.join(pluginsFolder, 'MCPPlugin.rbxmx');
+    const conflict = path.join(pluginsFolder, 'MCPInspectorPlugin.rbxmx');
+    fs.writeFileSync(target, 'working-main');
+    fs.writeFileSync(conflict, 'working-inspector');
+
+    expect(() => installPluginAsset({
+      pluginsFolder,
+      assetName: 'MCPPlugin.rbxmx',
+      otherAssetName: 'MCPInspectorPlugin.rbxmx',
+      source: pluginAsset({ includeDefaultConnection: false }),
+      expectedVersion: expectedPluginVersion,
+      expectedVariant: 'main',
+      rawPort: '43123',
+    })).toThrow(/default port/i);
+
+    expect(fs.readFileSync(target, 'utf8')).toBe('working-main');
+    expect(fs.readFileSync(conflict, 'utf8')).toBe('working-inspector');
+  });
+
+  test.each([
+    ['non-XML content', Buffer.from('not a plugin'), /Roblox XML/i],
+    [
+      'malformed XML',
+      Buffer.from(pluginAsset().toString('utf8').replace('</Properties>', '</Broken>')),
+      /XML/i,
+    ],
+    ['the wrong version', pluginAsset({ version: '9.9.9' }), /version 9\.9\.9.*1\.2\.3/i],
+    ['the wrong variant', pluginAsset({ variant: 'inspector' }), /variant inspector.*main/i],
+  ])('rejects %s before changing installed files', (_name, artifact, expectedError) => {
+    const pluginsFolder = createPluginsFolder();
+    const target = path.join(pluginsFolder, 'MCPPlugin.rbxmx');
+    const conflict = path.join(pluginsFolder, 'MCPInspectorPlugin.rbxmx');
+    fs.writeFileSync(target, 'working-main');
+    fs.writeFileSync(conflict, 'working-inspector');
+
+    expect(() => installPluginAsset({
+      pluginsFolder,
+      assetName: 'MCPPlugin.rbxmx',
+      otherAssetName: 'MCPInspectorPlugin.rbxmx',
+      source: artifact as Buffer,
+      expectedVersion: expectedPluginVersion,
+      expectedVariant: 'main',
+      rawPort: '',
+    })).toThrow(expectedError as RegExp);
+
+    expect(fs.readFileSync(target, 'utf8')).toBe('working-main');
+    expect(fs.readFileSync(conflict, 'utf8')).toBe('working-inspector');
+  });
+
+  test('does not mutate plugins while another installer holds the directory lock', () => {
+    const pluginsFolder = createPluginsFolder();
+    const target = path.join(pluginsFolder, 'MCPPlugin.rbxmx');
+    const conflict = path.join(pluginsFolder, 'MCPInspectorPlugin.rbxmx');
+    const lock = path.join(pluginsFolder, installLockName);
+    fs.writeFileSync(target, 'working-main');
+    fs.writeFileSync(conflict, 'working-inspector');
+    fs.mkdirSync(lock);
+    fs.writeFileSync(path.join(lock, 'owner.json'), '{"pid":1234}\n');
+
+    expect(() => installPluginAsset({
+      pluginsFolder,
+      assetName: 'MCPPlugin.rbxmx',
+      otherAssetName: 'MCPInspectorPlugin.rbxmx',
+      source: pluginAsset(),
+      expectedVersion: expectedPluginVersion,
+      expectedVariant: 'main',
+      rawPort: '',
+    })).toThrow(/already in progress/i);
+
+    expect(fs.readFileSync(target, 'utf8')).toBe('working-main');
+    expect(fs.readFileSync(conflict, 'utf8')).toBe('working-inspector');
+  });
+
+  test('requires manual recovery instead of racing to reclaim an old lock', () => {
+    const pluginsFolder = createPluginsFolder();
+    const target = path.join(pluginsFolder, 'MCPPlugin.rbxmx');
+    const conflict = path.join(pluginsFolder, 'MCPInspectorPlugin.rbxmx');
+    const lock = path.join(pluginsFolder, installLockName);
+    fs.writeFileSync(target, 'working-main');
+    fs.writeFileSync(conflict, 'working-inspector');
+    fs.mkdirSync(lock);
+    fs.writeFileSync(path.join(lock, 'owner.json'), '{"pid":1234}\n');
+    const oldTime = new Date(Date.now() - 10 * 60_000);
+    fs.utimesSync(lock, oldTime, oldTime);
+
+    expect(() => installPluginAsset({
+      pluginsFolder,
+      assetName: 'MCPPlugin.rbxmx',
+      otherAssetName: 'MCPInspectorPlugin.rbxmx',
+      source: pluginAsset(),
+      expectedVersion: expectedPluginVersion,
+      expectedVariant: 'main',
+      rawPort: '',
+    })).toThrow(/remove that lock directory and retry/i);
+
+    expect(fs.readFileSync(target, 'utf8')).toBe('working-main');
+    expect(fs.readFileSync(conflict, 'utf8')).toBe('working-inspector');
+    expect(fs.existsSync(lock)).toBe(true);
+  });
+
+  test('commits the configured target before removing the conflicting variant', () => {
+    const pluginsFolder = createPluginsFolder();
+    const target = path.join(pluginsFolder, 'MCPPlugin.rbxmx');
+    const conflict = path.join(pluginsFolder, 'MCPInspectorPlugin.rbxmx');
+    fs.writeFileSync(target, 'old-main');
+    fs.writeFileSync(conflict, 'working-inspector');
+
+    const result = installPluginAsset({
+      pluginsFolder,
+      assetName: 'MCPPlugin.rbxmx',
+      otherAssetName: 'MCPInspectorPlugin.rbxmx',
+      source: pluginAsset(),
+      expectedVersion: expectedPluginVersion,
+      expectedVariant: 'main',
+      rawPort: '43123',
+    });
+
+    expect(result).toEqual({ destination: target, installed: true });
+    expect(fs.readFileSync(target, 'utf8')).toContain('http://localhost:43123');
+    expect(fs.existsSync(conflict)).toBe(false);
+    expect(fs.readdirSync(pluginsFolder)).toEqual(['MCPPlugin.rbxmx']);
+  });
+
+  test('preserves the conflicting variant and cleans staging files when commit fails', () => {
+    const pluginsFolder = createPluginsFolder();
+    const target = path.join(pluginsFolder, 'MCPPlugin.rbxmx');
+    const conflict = path.join(pluginsFolder, 'MCPInspectorPlugin.rbxmx');
+    fs.mkdirSync(target);
+    fs.writeFileSync(path.join(target, 'sentinel'), 'unchanged');
+    fs.writeFileSync(conflict, 'working-inspector');
+
+    expect(() => installPluginAsset({
+      pluginsFolder,
+      assetName: 'MCPPlugin.rbxmx',
+      otherAssetName: 'MCPInspectorPlugin.rbxmx',
+      source: pluginAsset(),
+      expectedVersion: expectedPluginVersion,
+      expectedVariant: 'main',
+      rawPort: '',
+    })).toThrow();
+
+    expect(fs.readFileSync(path.join(target, 'sentinel'), 'utf8')).toBe('unchanged');
+    expect(fs.readFileSync(conflict, 'utf8')).toBe('working-inspector');
+    expect(fs.readdirSync(pluginsFolder).sort()).toEqual([
+      'MCPInspectorPlugin.rbxmx',
+      'MCPPlugin.rbxmx',
+    ]);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,13 @@ export {
   configurePluginAssetForPort,
   getPluginsFolder,
   handleVariantConflict,
+  installPluginAsset,
   isWSL,
+} from './install-plugin-helpers.js';
+export type {
+  InstallPluginAssetOptions,
+  PluginInstallResult,
+  PluginVariant,
 } from './install-plugin-helpers.js';
 export { RobloxCookieClient } from './roblox-cookie-client.js';
 export {

--- a/packages/core/src/install-plugin-helpers.ts
+++ b/packages/core/src/install-plugin-helpers.ts
@@ -1,7 +1,19 @@
-import { existsSync, unlinkSync } from 'fs';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'fs';
 import { execSync } from 'child_process';
-import { join } from 'path';
+import { randomUUID } from 'crypto';
+import { basename, join } from 'path';
 import { homedir } from 'os';
+import { isUtf8 } from 'buffer';
+import { SaxesParser } from 'saxes';
 import { getStudioPlatformCapabilities } from './studio-platform.js';
 
 // Shared helpers for the per-package install-plugin.ts in
@@ -142,3 +154,286 @@ export function handleVariantConflict({
 	      `Delete ${otherAssetName} manually or use the default CLI installer behavior to replace it.\n`,
 	  );
 	}
+
+export type PluginVariant = 'main' | 'inspector';
+
+export interface InstallPluginAssetOptions {
+  pluginsFolder: string;
+  assetName: string;
+  otherAssetName: string;
+  source: Buffer;
+  expectedVersion: string;
+  expectedVariant: PluginVariant;
+  rawPort?: string;
+  replaceVariant?: boolean;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+}
+
+export interface PluginInstallResult {
+  destination: string;
+  installed: boolean;
+}
+
+const PLUGIN_INSTALL_LOCK_NAME = '.robloxstudio-mcp-plugin-install.lock';
+
+function errorCode(error: unknown): string | undefined {
+  return (error as NodeJS.ErrnoException).code;
+}
+
+function acquirePluginInstallLock(
+  pluginsFolder: string,
+  warn: (message: string) => void,
+): () => void {
+  const lockPath = join(pluginsFolder, PLUGIN_INSTALL_LOCK_NAME);
+  const ownerPath = join(lockPath, 'owner.json');
+  const owner = {
+    pid: process.pid,
+    token: randomUUID(),
+    createdAt: Date.now(),
+  };
+
+  try {
+    mkdirSync(lockPath);
+  } catch (error) {
+    if (errorCode(error) !== 'EEXIST') throw error;
+    throw new Error(
+      `Another Studio plugin installation is already in progress: ${lockPath}. ` +
+        'If no installer is running, remove that lock directory and retry.',
+    );
+  }
+
+  try {
+    writeFileSync(ownerPath, `${JSON.stringify(owner)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
+  } catch (error) {
+    try {
+      rmSync(lockPath, { recursive: true, force: true });
+    } catch (cleanupError) {
+      warn(`[install-plugin] Could not clean failed install lock ${lockPath}: ${cleanupError}`);
+    }
+    throw error;
+  }
+
+  return () => {
+    try {
+      const currentOwner = JSON.parse(readFileSync(ownerPath, 'utf8')) as {
+        pid?: unknown;
+        token?: unknown;
+      };
+      if (currentOwner.pid === owner.pid && currentOwner.token === owner.token) {
+        rmSync(lockPath, { recursive: true, force: true });
+      }
+    } catch (error) {
+      if (errorCode(error) !== 'ENOENT') {
+        warn(`[install-plugin] Could not release install lock ${lockPath}: ${error}`);
+      }
+    }
+  };
+}
+
+function assertAssetFileName(name: string, field: string): void {
+  if (name === '' || basename(name) !== name) {
+    throw new Error(`${field} must be a file name, received ${JSON.stringify(name)}`);
+  }
+}
+
+function embeddedPluginValue(
+  source: string,
+  name: 'CURRENT_VERSION' | 'PLUGIN_VARIANT',
+  assetName: string,
+): string {
+  const pattern = new RegExp(`\\blocal\\s+${name}\\s*=\\s*"([^"]+)"\\s*;?`, 'g');
+  const matches = [...source.matchAll(pattern)];
+  if (matches.length !== 1) {
+    throw new Error(
+      `${assetName} must contain exactly one embedded ${name}; found ${matches.length}.`,
+    );
+  }
+  return matches[0][1];
+}
+
+interface ParsedPluginElement {
+  name: string;
+  attributes: Record<string, string>;
+}
+
+const PLUGIN_SOURCE_CLASSES: Record<string, true> = {
+  Script: true,
+  ModuleScript: true,
+  LocalScript: true,
+};
+
+function parsePluginScriptSources(source: Buffer, assetName: string): string[] {
+  if (!isUtf8(source)) {
+    throw new Error(`${assetName} is not valid UTF-8 Roblox XML.`);
+  }
+
+  const text = source.toString('utf8');
+  const elementStack: ParsedPluginElement[] = [];
+  const scriptSources: string[] = [];
+  let rootName: string | undefined;
+  let currentSource: { depth: number; text: string } | undefined;
+  const parser = new SaxesParser({ fragment: false, xmlns: false });
+
+  parser.on('doctype', () => {
+    throw new Error('DOCTYPE declarations are not allowed in plugin artifacts.');
+  });
+  parser.on('opentag', (tag) => {
+    if (elementStack.length === 0) rootName = tag.name;
+
+    if (
+      currentSource === undefined &&
+      tag.name === 'string' &&
+      tag.attributes.name === 'Source'
+    ) {
+      const nearestItem = [...elementStack]
+        .reverse()
+        .find((element) => element.name === 'Item');
+      const sourceClass = nearestItem?.attributes.class;
+      if (
+        sourceClass !== undefined &&
+        PLUGIN_SOURCE_CLASSES[sourceClass] === true
+      ) {
+        currentSource = { depth: elementStack.length, text: '' };
+      }
+    }
+
+    elementStack.push({ name: tag.name, attributes: tag.attributes });
+  });
+  parser.on('text', (value) => {
+    if (currentSource !== undefined) currentSource.text += value;
+  });
+  parser.on('cdata', (value) => {
+    if (currentSource !== undefined) currentSource.text += value;
+  });
+  parser.on('closetag', (tag) => {
+    if (
+      currentSource !== undefined &&
+      tag.name === 'string' &&
+      elementStack.length === currentSource.depth + 1
+    ) {
+      scriptSources.push(currentSource.text);
+      currentSource = undefined;
+    }
+    elementStack.pop();
+  });
+
+  try {
+    parser.write(text).close();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`${assetName} is not well-formed Roblox XML: ${detail}`, {
+      cause: error,
+    });
+  }
+
+  if (rootName !== 'roblox' || scriptSources.length === 0) {
+    throw new Error(
+      `${assetName} is not a Roblox XML model containing a Script source.`,
+    );
+  }
+  return scriptSources;
+}
+
+function assertPluginAssetIdentity(
+  source: Buffer,
+  assetName: string,
+  expectedVersion: string,
+  expectedVariant: PluginVariant,
+): void {
+  const pluginSource = parsePluginScriptSources(source, assetName).join('\n');
+  const actualVersion = embeddedPluginValue(
+    pluginSource,
+    'CURRENT_VERSION',
+    assetName,
+  );
+  if (actualVersion !== expectedVersion) {
+    throw new Error(
+      `${assetName} embeds version ${actualVersion}; expected ${expectedVersion}.`,
+    );
+  }
+
+  const actualVariant = embeddedPluginValue(pluginSource, 'PLUGIN_VARIANT', assetName);
+  if (actualVariant !== expectedVariant) {
+    throw new Error(
+      `${assetName} embeds variant ${actualVariant}; expected ${expectedVariant}.`,
+    );
+  }
+}
+
+function installedFileMatches(source: Buffer, destination: string): boolean {
+  if (!existsSync(destination)) return false;
+  if (!lstatSync(destination).isFile()) return false;
+  const installed = readFileSync(destination);
+  return installed.length === source.length && installed.equals(source);
+}
+
+/**
+ * Configures, validates, and commits a plugin artifact without exposing a
+ * partially written live file. The conflicting variant is touched only after
+ * the requested target is known to be valid and present.
+ */
+export function installPluginAsset({
+  pluginsFolder,
+  assetName,
+  otherAssetName,
+  source,
+  expectedVersion,
+  expectedVariant,
+  rawPort,
+  replaceVariant = true,
+  log = console.log,
+  warn = console.warn,
+}: InstallPluginAssetOptions): PluginInstallResult {
+  assertAssetFileName(assetName, 'assetName');
+  assertAssetFileName(otherAssetName, 'otherAssetName');
+  if (assetName === otherAssetName) {
+    throw new Error('assetName and otherAssetName must identify different files.');
+  }
+
+  const configured = configurePluginAssetForPort(source, rawPort);
+  assertPluginAssetIdentity(configured, assetName, expectedVersion, expectedVariant);
+
+  mkdirSync(pluginsFolder, { recursive: true });
+  const destination = join(pluginsFolder, assetName);
+  const releaseLock = acquirePluginInstallLock(pluginsFolder, warn);
+
+  try {
+    let installed = false;
+
+    if (!installedFileMatches(configured, destination)) {
+      const staged = join(
+        pluginsFolder,
+        `.${assetName}.${process.pid}.${randomUUID()}.tmp`,
+      );
+      try {
+        writeFileSync(staged, configured, { flag: 'wx' });
+        renameSync(staged, destination);
+        installed = true;
+      } finally {
+        try {
+          unlinkSync(staged);
+        } catch (error) {
+          if (errorCode(error) !== 'ENOENT') {
+            warn(`[install-plugin] Could not remove staging file ${staged}: ${error}`);
+          }
+        }
+      }
+    }
+
+    handleVariantConflict({
+      pluginsFolder,
+      otherAssetName,
+      replace: replaceVariant,
+      log,
+      warn,
+    });
+
+    return { destination, installed };
+  } finally {
+    releaseLock();
+  }
+}

--- a/packages/robloxstudio-mcp-inspector/src/install-plugin.ts
+++ b/packages/robloxstudio-mcp-inspector/src/install-plugin.ts
@@ -1,12 +1,11 @@
-import { createWriteStream, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { get } from 'https';
 import { IncomingMessage } from 'http';
 import {
-  configurePluginAssetForPort,
   getPluginsFolder,
-  handleVariantConflict,
+  installPluginAsset,
 } from '@chrrxs/robloxstudio-mcp-core';
 
 const REPO = 'chrrxs/robloxstudio-mcp';
@@ -14,6 +13,7 @@ const ASSET_NAME = 'MCPInspectorPlugin.rbxmx';
 const OTHER_VARIANT = 'MCPPlugin.rbxmx';
 const TIMEOUT_MS = 30_000;
 const MAX_REDIRECTS = 5;
+const MAX_ASSET_BYTES = 64 * 1024 * 1024;
 
 interface InstallOptions {
   sourcePath?: string;
@@ -30,33 +30,37 @@ function httpsGet(url: string): Promise<IncomingMessage> {
   });
 }
 
-async function download(url: string, dest: string, redirects = 0): Promise<void> {
+async function download(url: string, redirects = 0): Promise<Buffer> {
   const res = await httpsGet(url);
 
   if (res.statusCode === 301 || res.statusCode === 302) {
     if (redirects >= MAX_REDIRECTS) throw new Error(`Too many redirects (max ${MAX_REDIRECTS})`);
     const location = res.headers.location;
     if (!location) throw new Error('Redirect with no location header');
-    return download(location, dest, redirects + 1);
+    for await (const _chunk of res) {
+      // Drain the response before following the redirect.
+    }
+    return download(location, redirects + 1);
   }
 
   if (res.statusCode !== 200) {
     throw new Error(`Download failed: HTTP ${res.statusCode}`);
   }
 
-  return new Promise((resolve, reject) => {
-    const file = createWriteStream(dest);
-    const cleanup = (err: Error) => {
-      file.close(() => {
-        try { unlinkSync(dest); } catch { /* already gone */ }
-        reject(err);
-      });
-    };
-    res.pipe(file);
-    file.on('finish', () => { file.close(); resolve(); });
-    file.on('error', cleanup);
-    res.on('error', cleanup);
-  });
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of res) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += bytes.length;
+    if (totalBytes > MAX_ASSET_BYTES) {
+      res.destroy();
+      throw new Error(
+        `${ASSET_NAME} download exceeds the ${MAX_ASSET_BYTES}-byte limit.`,
+      );
+    }
+    chunks.push(bytes);
+  }
+  return Buffer.concat(chunks, totalBytes);
 }
 
 async function fetchJson(url: string): Promise<unknown> {
@@ -69,28 +73,6 @@ async function fetchJson(url: string): Promise<unknown> {
     chunks.push(chunk as Buffer);
   }
   return JSON.parse(Buffer.concat(chunks).toString());
-}
-
-function prepareInstall({
-  replaceVariant,
-  log,
-  warn,
-}: Required<Pick<InstallOptions, 'replaceVariant' | 'log' | 'warn'>>): string {
-  const pluginsFolder = getPluginsFolder();
-
-  if (!existsSync(pluginsFolder)) {
-    mkdirSync(pluginsFolder, { recursive: true });
-  }
-
-  handleVariantConflict({
-    pluginsFolder,
-    otherAssetName: OTHER_VARIANT,
-    replace: replaceVariant,
-    log,
-    warn,
-  });
-
-  return pluginsFolder;
 }
 
 function bundledAssetPath(): string | null {
@@ -116,48 +98,31 @@ function packageVersion(): string {
   return pkg.version;
 }
 
-function bundledPluginVersion(source: string): string | null {
-  const match = readFileSync(source, 'utf8').match(/local CURRENT_VERSION = "([^"]+)"/);
-  return match ? match[1] : null;
-}
-
-function assertBundledPluginVersion(source: string): void {
-  const expected = packageVersion();
-  const actual = bundledPluginVersion(source);
-  if (actual !== expected) {
-    throw new Error(
-      `Bundled ${ASSET_NAME} version ${actual ?? 'unknown'} does not match package version ${expected}. ` +
-      'Run npm run build:plugin:inspector before starting with --auto-install-plugin.',
-    );
-  }
-}
-
-function filesMatch(expected: Buffer, actualPath: string): boolean {
-  if (!existsSync(actualPath)) return false;
-  const actual = readFileSync(actualPath);
-  return expected.length === actual.length && expected.equals(actual);
-}
-
 export async function installBundledPlugin(options: InstallOptions = {}): Promise<void> {
   const log = options.log ?? console.log;
   const warn = options.warn ?? console.warn;
   const replaceVariant = options.replaceVariant ?? true;
-  const source = resolvePluginAssetPath(options.sourcePath);
-  if (!source) {
+  const sourcePath = resolvePluginAssetPath(options.sourcePath);
+  if (!sourcePath) {
     throw new Error(
       `Bundled ${ASSET_NAME} not found. Run npm run build:plugin:inspector in this worktree first.`,
     );
   }
-  assertBundledPluginVersion(source);
 
-  const pluginsFolder = prepareInstall({ replaceVariant, log, warn });
-  const dest = join(pluginsFolder, ASSET_NAME);
-  const configured = configurePluginAssetForPort(readFileSync(source));
-
-  if (filesMatch(configured, dest)) return;
-
-  writeFileSync(dest, configured);
-  log(`Installed ${ASSET_NAME} to ${dest}`);
+  const result = await installPluginAsset({
+    pluginsFolder: getPluginsFolder(),
+    assetName: ASSET_NAME,
+    otherAssetName: OTHER_VARIANT,
+    source: readFileSync(sourcePath),
+    expectedVersion: packageVersion(),
+    expectedVariant: 'inspector',
+    replaceVariant,
+    log,
+    warn,
+  });
+  if (result.installed) {
+    log(`Installed ${ASSET_NAME} to ${result.destination}`);
+  }
 }
 
 export async function installPlugin(options: InstallOptions = {}): Promise<void> {
@@ -168,18 +133,24 @@ export async function installPlugin(options: InstallOptions = {}): Promise<void>
   if (options.sourcePath !== undefined && !bundled) {
     throw new Error(`Plugin asset not found at explicit path ${options.sourcePath}.`);
   }
-  const pluginsFolder = prepareInstall({ replaceVariant, log, warn });
 
   if (bundled) {
-    assertBundledPluginVersion(bundled);
-    const dest = join(pluginsFolder, ASSET_NAME);
-    const configured = configurePluginAssetForPort(readFileSync(bundled));
-    if (filesMatch(configured, dest)) {
+    const result = await installPluginAsset({
+      pluginsFolder: getPluginsFolder(),
+      assetName: ASSET_NAME,
+      otherAssetName: OTHER_VARIANT,
+      source: readFileSync(bundled),
+      expectedVersion: packageVersion(),
+      expectedVariant: 'inspector',
+      replaceVariant,
+      log,
+      warn,
+    });
+    if (result.installed) {
+      log(`Installed bundled ${ASSET_NAME} to ${result.destination}`);
+    } else {
       log(`${ASSET_NAME} already installed.`);
-      return;
     }
-    writeFileSync(dest, configured);
-    log(`Installed bundled ${ASSET_NAME} to ${dest}`);
     return;
   }
 
@@ -194,11 +165,22 @@ export async function installPlugin(options: InstallOptions = {}): Promise<void>
     throw new Error(`${ASSET_NAME} not found in release ${release.tag_name}`);
   }
 
-  const dest = join(pluginsFolder, ASSET_NAME);
   log(`Downloading ${ASSET_NAME} from ${release.tag_name}...`);
-  await download(asset.browser_download_url, dest);
-  const downloaded = readFileSync(dest);
-  const configured = configurePluginAssetForPort(downloaded);
-  if (configured !== downloaded) writeFileSync(dest, configured);
-  log(`Installed to ${dest}`);
+  const downloaded = await download(asset.browser_download_url);
+  const result = await installPluginAsset({
+    pluginsFolder: getPluginsFolder(),
+    assetName: ASSET_NAME,
+    otherAssetName: OTHER_VARIANT,
+    source: downloaded,
+    expectedVersion: release.tag_name.replace(/^v/, ''),
+    expectedVariant: 'inspector',
+    replaceVariant,
+    log,
+    warn,
+  });
+  if (result.installed) {
+    log(`Installed to ${result.destination}`);
+  } else {
+    log(`${ASSET_NAME} already installed.`);
+  }
 }

--- a/packages/robloxstudio-mcp/src/install-plugin.ts
+++ b/packages/robloxstudio-mcp/src/install-plugin.ts
@@ -1,12 +1,11 @@
-import { createWriteStream, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { get } from 'https';
 import { IncomingMessage } from 'http';
 import {
-  configurePluginAssetForPort,
   getPluginsFolder,
-  handleVariantConflict,
+  installPluginAsset,
 } from '@chrrxs/robloxstudio-mcp-core';
 
 const REPO = 'chrrxs/robloxstudio-mcp';
@@ -14,6 +13,7 @@ const ASSET_NAME = 'MCPPlugin.rbxmx';
 const OTHER_VARIANT = 'MCPInspectorPlugin.rbxmx';
 const TIMEOUT_MS = 30_000;
 const MAX_REDIRECTS = 5;
+const MAX_ASSET_BYTES = 64 * 1024 * 1024;
 
 interface InstallOptions {
   dev?: boolean;
@@ -31,33 +31,37 @@ function httpsGet(url: string): Promise<IncomingMessage> {
   });
 }
 
-async function download(url: string, dest: string, redirects = 0): Promise<void> {
+async function download(url: string, redirects = 0): Promise<Buffer> {
   const res = await httpsGet(url);
 
   if (res.statusCode === 301 || res.statusCode === 302) {
     if (redirects >= MAX_REDIRECTS) throw new Error(`Too many redirects (max ${MAX_REDIRECTS})`);
     const location = res.headers.location;
     if (!location) throw new Error('Redirect with no location header');
-    return download(location, dest, redirects + 1);
+    for await (const _chunk of res) {
+      // Drain the response before following the redirect.
+    }
+    return download(location, redirects + 1);
   }
 
   if (res.statusCode !== 200) {
     throw new Error(`Download failed: HTTP ${res.statusCode}`);
   }
 
-  return new Promise((resolve, reject) => {
-    const file = createWriteStream(dest);
-    const cleanup = (err: Error) => {
-      file.close(() => {
-        try { unlinkSync(dest); } catch { /* already gone */ }
-        reject(err);
-      });
-    };
-    res.pipe(file);
-    file.on('finish', () => { file.close(); resolve(); });
-    file.on('error', cleanup);
-    res.on('error', cleanup);
-  });
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of res) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += bytes.length;
+    if (totalBytes > MAX_ASSET_BYTES) {
+      res.destroy();
+      throw new Error(
+        `${ASSET_NAME} download exceeds the ${MAX_ASSET_BYTES}-byte limit.`,
+      );
+    }
+    chunks.push(bytes);
+  }
+  return Buffer.concat(chunks, totalBytes);
 }
 
 async function fetchJson(url: string): Promise<unknown> {
@@ -87,28 +91,6 @@ async function findDevRelease(): Promise<{ tag_name: string; assets: { name: str
   return prerelease;
 }
 
-function prepareInstall({
-  replaceVariant,
-  log,
-  warn,
-}: Required<Pick<InstallOptions, 'replaceVariant' | 'log' | 'warn'>>): string {
-  const pluginsFolder = getPluginsFolder();
-
-  if (!existsSync(pluginsFolder)) {
-    mkdirSync(pluginsFolder, { recursive: true });
-  }
-
-  handleVariantConflict({
-    pluginsFolder,
-    otherAssetName: OTHER_VARIANT,
-    replace: replaceVariant,
-    log,
-    warn,
-  });
-
-  return pluginsFolder;
-}
-
 function bundledAssetPath(): string | null {
   const currentDir = dirname(fileURLToPath(import.meta.url));
   const candidates = [
@@ -132,48 +114,31 @@ function packageVersion(): string {
   return pkg.version;
 }
 
-function bundledPluginVersion(source: string): string | null {
-  const match = readFileSync(source, 'utf8').match(/local CURRENT_VERSION = "([^"]+)"/);
-  return match ? match[1] : null;
-}
-
-function assertBundledPluginVersion(source: string): void {
-  const expected = packageVersion();
-  const actual = bundledPluginVersion(source);
-  if (actual !== expected) {
-    throw new Error(
-      `Bundled ${ASSET_NAME} version ${actual ?? 'unknown'} does not match package version ${expected}. ` +
-      'Run npm run build:plugin before starting with --auto-install-plugin.',
-    );
-  }
-}
-
-function filesMatch(expected: Buffer, actualPath: string): boolean {
-  if (!existsSync(actualPath)) return false;
-  const actual = readFileSync(actualPath);
-  return expected.length === actual.length && expected.equals(actual);
-}
-
 export async function installBundledPlugin(options: InstallOptions = {}): Promise<void> {
   const log = options.log ?? console.log;
   const warn = options.warn ?? console.warn;
   const replaceVariant = options.replaceVariant ?? true;
-  const source = resolvePluginAssetPath(options.sourcePath);
-  if (!source) {
+  const sourcePath = resolvePluginAssetPath(options.sourcePath);
+  if (!sourcePath) {
     throw new Error(
       `Bundled ${ASSET_NAME} not found. Run npm run build:plugin in this worktree first.`,
     );
   }
-  assertBundledPluginVersion(source);
 
-  const pluginsFolder = prepareInstall({ replaceVariant, log, warn });
-  const dest = join(pluginsFolder, ASSET_NAME);
-  const configured = configurePluginAssetForPort(readFileSync(source));
-
-  if (filesMatch(configured, dest)) return;
-
-  writeFileSync(dest, configured);
-  log(`Installed ${ASSET_NAME} to ${dest}`);
+  const result = await installPluginAsset({
+    pluginsFolder: getPluginsFolder(),
+    assetName: ASSET_NAME,
+    otherAssetName: OTHER_VARIANT,
+    source: readFileSync(sourcePath),
+    expectedVersion: packageVersion(),
+    expectedVariant: 'main',
+    replaceVariant,
+    log,
+    warn,
+  });
+  if (result.installed) {
+    log(`Installed ${ASSET_NAME} to ${result.destination}`);
+  }
 }
 
 export async function installPlugin(options: InstallOptions = {}): Promise<void> {
@@ -185,18 +150,24 @@ export async function installPlugin(options: InstallOptions = {}): Promise<void>
   if (options.sourcePath !== undefined && !bundled) {
     throw new Error(`Plugin asset not found at explicit path ${options.sourcePath}.`);
   }
-  const pluginsFolder = prepareInstall({ replaceVariant, log, warn });
 
   if (bundled) {
-    assertBundledPluginVersion(bundled);
-    const dest = join(pluginsFolder, ASSET_NAME);
-    const configured = configurePluginAssetForPort(readFileSync(bundled));
-    if (filesMatch(configured, dest)) {
+    const result = await installPluginAsset({
+      pluginsFolder: getPluginsFolder(),
+      assetName: ASSET_NAME,
+      otherAssetName: OTHER_VARIANT,
+      source: readFileSync(bundled),
+      expectedVersion: packageVersion(),
+      expectedVariant: 'main',
+      replaceVariant,
+      log,
+      warn,
+    });
+    if (result.installed) {
+      log(`Installed bundled ${ASSET_NAME} to ${result.destination}`);
+    } else {
       log(`${ASSET_NAME} already installed.`);
-      return;
     }
-    writeFileSync(dest, configured);
-    log(`Installed bundled ${ASSET_NAME} to ${dest}`);
     return;
   }
 
@@ -213,11 +184,22 @@ export async function installPlugin(options: InstallOptions = {}): Promise<void>
     throw new Error(`${ASSET_NAME} not found in release ${release.tag_name}`);
   }
 
-  const dest = join(pluginsFolder, ASSET_NAME);
   log(`Downloading ${ASSET_NAME} from ${release.tag_name}...`);
-  await download(asset.browser_download_url, dest);
-  const downloaded = readFileSync(dest);
-  const configured = configurePluginAssetForPort(downloaded);
-  if (configured !== downloaded) writeFileSync(dest, configured);
-  log(`Installed to ${dest}`);
+  const downloaded = await download(asset.browser_download_url);
+  const result = await installPluginAsset({
+    pluginsFolder: getPluginsFolder(),
+    assetName: ASSET_NAME,
+    otherAssetName: OTHER_VARIANT,
+    source: downloaded,
+    expectedVersion: release.tag_name.replace(/^v/, ''),
+    expectedVariant: 'main',
+    replaceVariant,
+    log,
+    warn,
+  });
+  if (result.installed) {
+    log(`Installed to ${result.destination}`);
+  } else {
+    log(`${ASSET_NAME} already installed.`);
+  }
 }

--- a/scripts/build-plugin.mjs
+++ b/scripts/build-plugin.mjs
@@ -1,9 +1,21 @@
 #!/usr/bin/env node
 
-import { readFileSync, readdirSync, writeFileSync, copyFileSync, existsSync, mkdirSync, statSync, unlinkSync } from 'fs';
+import {
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  unlinkSync,
+  renameSync,
+  rmSync,
+  constants,
+} from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join, basename } from 'path';
 import { homedir } from 'os';
+import { randomUUID } from 'crypto';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
@@ -256,20 +268,92 @@ function resolvePluginsDir() {
   }
 }
 
+const PLUGIN_INSTALL_LOCK_NAME = '.robloxstudio-mcp-plugin-install.lock';
+
+function acquirePluginInstallLock(pluginsDir) {
+  const lockPath = join(pluginsDir, PLUGIN_INSTALL_LOCK_NAME);
+  const ownerPath = join(lockPath, 'owner.json');
+  const owner = {
+    pid: process.pid,
+    token: randomUUID(),
+    createdAt: Date.now(),
+  };
+
+  try {
+    mkdirSync(lockPath);
+  } catch (error) {
+    if (error?.code !== 'EEXIST') throw error;
+    throw new Error(
+      `Another Studio plugin installation is already in progress: ${lockPath}. ` +
+        'If no installer is running, remove that lock directory and retry.',
+    );
+  }
+
+  try {
+    writeFileSync(ownerPath, `${JSON.stringify(owner)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
+  } catch (error) {
+    try {
+      rmSync(lockPath, { recursive: true, force: true });
+    } catch (cleanupError) {
+      console.warn(`[build-plugin] Could not clean failed install lock ${lockPath}: ${cleanupError}`);
+    }
+    throw error;
+  }
+
+  return () => {
+    try {
+      const currentOwner = JSON.parse(readFileSync(ownerPath, 'utf8'));
+      if (currentOwner.pid === owner.pid && currentOwner.token === owner.token) {
+        rmSync(lockPath, { recursive: true, force: true });
+      }
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        console.warn(`[build-plugin] Could not release install lock ${lockPath}: ${error}`);
+      }
+    }
+  };
+}
+
 if (process.argv.includes('--build-only')) {
   console.log('Skipped Studio install (--build-only).');
 } else {
   const pluginsDir = resolvePluginsDir();
   if (pluginsDir) {
     mkdirSync(pluginsDir, { recursive: true });
-    const otherInstallPath = join(pluginsDir, otherVariant.outputName);
-    if (existsSync(otherInstallPath)) {
-      unlinkSync(otherInstallPath);
-      console.log(`Removed conflicting ${otherVariant.outputName} from ${pluginsDir}`);
-    }
     const installPath = join(pluginsDir, variant.outputName);
-    copyFileSync(outputPath, installPath);
-    console.log(`Installed to ${installPath}`);
+    const tempInstallPath = join(pluginsDir, `.${variant.outputName}.${randomUUID()}.tmp`);
+    let releaseInstallLock;
+    try {
+      copyFileSync(outputPath, tempInstallPath, constants.COPYFILE_EXCL);
+      releaseInstallLock = acquirePluginInstallLock(pluginsDir);
+      renameSync(tempInstallPath, installPath);
+
+      const otherInstallPath = join(pluginsDir, otherVariant.outputName);
+      if (existsSync(otherInstallPath)) {
+        try {
+          unlinkSync(otherInstallPath);
+          console.log(`Removed conflicting ${otherVariant.outputName} from ${pluginsDir}`);
+        } catch (error) {
+          console.warn(
+            `[build-plugin] Could not remove conflicting ${otherInstallPath}: ${error}. ` +
+              'Continuing with both variants present.',
+          );
+        }
+      }
+      console.log(`Installed to ${installPath}`);
+    } finally {
+      try {
+        unlinkSync(tempInstallPath);
+      } catch (error) {
+        if (error?.code !== 'ENOENT') {
+          console.warn(`[build-plugin] Could not remove staging file ${tempInstallPath}: ${error}`);
+        }
+      }
+      releaseInstallLock?.();
+    }
   } else {
     console.log(
       `Skipped install: no Studio plugins folder resolvable on ${process.platform}. ` +


### PR DESCRIPTION
## Summary
- stage, validate, and atomically commit plugin artifacts before removing the conflicting variant
- share the transaction across the main and inspector installers and apply the same ordering to local builds
- serialize concurrent installs with a fail-safe cross-process lock and add failure-path regressions

## Validation
- `npm test`
- `npm run build`
- `npm run lint`
- real main/inspector artifact installs plus injected configuration, download, commit, and concurrency failures

Closes #61