### PR TITLE
Keep large script searches responsive in Studio

### DIFF
--- a/packages/core/src/__tests__/http-server.test.ts
+++ b/packages/core/src/__tests__/http-server.test.ts
@@ -525,6 +525,37 @@ describe('HTTP Server', () => {
       expect(app.isPluginConnected()).toBe(false);
     });
 
+    test('forwards a validated proxy timeout to the Studio bridge', async () => {
+      const sendRequest = jest.spyOn(bridge, 'sendRequest').mockResolvedValue({ results: [] });
+
+      const response = await request(app).post('/proxy').send({
+        endpoint: '/api/grep-scripts',
+        data: { pattern: 'needle' },
+        targetInstanceId: 'place:test',
+        targetRole: 'edit',
+        timeoutMs: 120_000,
+      }).expect(200);
+
+      expect(response.body).toEqual({ response: { results: [] } });
+      expect(sendRequest).toHaveBeenCalledWith(
+        '/api/grep-scripts',
+        { pattern: 'needle' },
+        'place:test',
+        'edit',
+        120_000,
+      );
+    });
+
+    test('rejects invalid proxy timeouts', async () => {
+      await request(app).post('/proxy').send({
+        endpoint: '/api/grep-scripts',
+        data: { pattern: 'needle' },
+        targetInstanceId: 'place:test',
+        targetRole: 'edit',
+        timeoutMs: 0,
+      }).expect(400, { error: 'timeoutMs must be an integer between 1 and 300000' });
+    });
+
     test('disconnect rejects pending requests targeting that tuple', async () => {
       await request(app).post('/ready').send(READY_BODY).expect(200);
       const p1 = bridge.sendRequest('/api/test1', {}, 'place:test', 'edit');

--- a/packages/core/src/__tests__/proxy-bridge-service.test.ts
+++ b/packages/core/src/__tests__/proxy-bridge-service.test.ts
@@ -131,4 +131,41 @@ describe('ProxyBridgeService', () => {
       fetchMock.mockRestore();
     }
   });
+
+  test('forwards request-specific timeouts to the primary bridge', async () => {
+    const timeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+    const fetchMock = jest.spyOn(globalThis, 'fetch').mockImplementation(async (input: any, init?: any) => {
+      const url = String(input);
+      if (url === 'http://primary/instances') {
+        return { ok: true, json: async () => ({ instances: [] }) } as any;
+      }
+      if (url === 'http://primary/proxy') {
+        expect(JSON.parse(String(init.body))).toMatchObject({
+          endpoint: '/api/grep-scripts',
+          targetInstanceId: 'place:test',
+          targetRole: 'edit',
+          timeoutMs: 120_000,
+        });
+        return { ok: true, json: async () => ({ response: { results: [] } }) } as any;
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+
+    const proxy = new ProxyBridgeService('http://primary');
+    try {
+      await proxy.waitForInitialRefresh();
+      await expect(proxy.sendRequest(
+        '/api/grep-scripts',
+        { pattern: 'needle' },
+        'place:test',
+        'edit',
+        120_000,
+      )).resolves.toEqual({ results: [] });
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 125_000);
+    } finally {
+      proxy.stop();
+      fetchMock.mockRestore();
+      timeoutSpy.mockRestore();
+    }
+  });
 });

--- a/packages/core/src/__tests__/studio-grep-responsiveness.test.ts
+++ b/packages/core/src/__tests__/studio-grep-responsiveness.test.ts
@@ -1,0 +1,317 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vm from 'vm';
+import { build as esbuildBuild, type Plugin } from 'esbuild';
+import { BridgeService } from '../bridge-service.js';
+import { RobloxStudioTools } from '../tools/index.js';
+
+interface QueryHandlersModule {
+  grepScripts(request: Record<string, unknown>): Record<string, unknown>;
+}
+
+interface UtilsModule {
+  splitLines(source: string): [string[], boolean];
+}
+
+interface TestInstance {
+  Name: string;
+  ClassName: string;
+  source?: string;
+  IsA(className: string): boolean;
+  GetChildren(): TestInstance[];
+}
+
+let utilsBundlePromise: Promise<string> | undefined;
+let queryHandlersBundlePromise: Promise<string> | undefined;
+
+function repositoryRoot(): string {
+  const cwd = process.cwd();
+  return fs.existsSync(path.join(cwd, 'studio-plugin')) ? cwd : path.resolve(cwd, '../..');
+}
+
+function robloxPcall(callback: (...args: never[]) => unknown): [boolean, unknown] {
+  try {
+    return [true, callback()];
+  } catch (error) {
+    return [false, error];
+  }
+}
+
+function robloxFind(value: string, pattern: string, start = 1): [number | undefined, number | undefined] {
+  const index = value.indexOf(pattern, Math.max(0, start - 1));
+  return index < 0 ? [undefined, undefined] : [index + 1, index + pattern.length];
+}
+
+function installRobloxStringHelpers(context: vm.Context): void {
+  vm.runInContext(`
+    String.prototype.gsub = function(search, replacement) {
+      const parts = String(this).split(search);
+      return [parts.join(replacement), parts.length - 1];
+    };
+    String.prototype.sub = function(start, finish) {
+      const from = start > 0 ? start - 1 : this.length + start;
+      const to = finish === undefined ? this.length : (finish > 0 ? finish : this.length + finish + 1);
+      return String(this).slice(from, to);
+    };
+    String.prototype.lower = function() { return String(this).toLowerCase(); };
+    String.prototype.size = function() { return this.length; };
+    String.prototype.find = function(pattern, start) {
+      return globalThis.__STRING_FIND__(String(this), pattern, start);
+    };
+    Array.prototype.size = function() { return this.length; };
+  `, context);
+}
+
+async function loadUtils(): Promise<UtilsModule> {
+  utilsBundlePromise ??= esbuildBuild({
+    entryPoints: [path.join(repositoryRoot(), 'studio-plugin/src/modules/Utils.ts')],
+    bundle: true,
+    write: false,
+    platform: 'node',
+    format: 'cjs',
+    target: 'node20',
+    logLevel: 'silent',
+  }).then((result) => result.outputFiles[0].text);
+  const bundle = await utilsBundlePromise;
+  const commonJsModule = { exports: {} as unknown };
+  const context = vm.createContext({
+    module: commonJsModule,
+    exports: commonJsModule.exports,
+    console,
+    game: { GetService: () => ({}) },
+    __STRING_FIND__: robloxFind,
+  });
+  installRobloxStringHelpers(context);
+  vm.runInContext(bundle, context);
+  const loaded = commonJsModule.exports as UtilsModule & { default?: UtilsModule };
+  return loaded.default ?? loaded;
+}
+
+async function loadQueryHandlers(
+  sources: string[],
+  options: { throwOnFirstRead?: boolean } = {},
+): Promise<{
+  handlers: QueryHandlersModule;
+  splitCalls: () => number;
+  waitCalls: () => number;
+  onWait(callback: () => void): void;
+  grepInContext(request: Record<string, unknown>): Record<string, unknown>;
+}> {
+  const scripts: TestInstance[] = sources.map((source, index) => ({
+    Name: `Script${index}`,
+    ClassName: 'ModuleScript',
+    source,
+    IsA: (className) => className === 'LuaSourceContainer',
+    GetChildren: () => [],
+  }));
+  const root: TestInstance = {
+    Name: 'game',
+    ClassName: 'DataModel',
+    IsA: () => false,
+    GetChildren: () => scripts,
+  };
+
+  let splitCallCount = 0;
+  let waitCallCount = 0;
+  let waitCallback: (() => void) | undefined;
+  let clock = 0;
+  let shouldThrowOnRead = options.throwOnFirstRead ?? false;
+  const utils = {
+    getInstancePath: (instance: TestInstance) => `game.${instance.Name}`,
+    getInstanceByPath: () => root,
+    readScriptSource: (instance: TestInstance) => {
+      if (shouldThrowOnRead) {
+        shouldThrowOnRead = false;
+        throw new Error('source read failed');
+      }
+      return instance.source ?? '';
+    },
+    splitLines: (source: string) => {
+      splitCallCount++;
+      const lines = source.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n') as string[] & { size(): number };
+      lines.size = () => lines.length;
+      return [lines, false];
+    },
+  };
+  const dependencies: Plugin = {
+    name: 'studio-grep-responsiveness-dependencies',
+    setup(build) {
+      build.onResolve({ filter: /^\.\.\/Utils$/ }, () => ({
+        path: 'Utils',
+        namespace: 'studio-grep-responsiveness',
+      }));
+      build.onLoad({ filter: /.*/, namespace: 'studio-grep-responsiveness' }, () => ({
+        contents: 'export default globalThis.__UTILS__;',
+        loader: 'js',
+      }));
+    },
+  };
+  queryHandlersBundlePromise ??= esbuildBuild({
+    entryPoints: [path.join(repositoryRoot(), 'studio-plugin/src/modules/handlers/QueryHandlers.ts')],
+    bundle: true,
+    write: false,
+    platform: 'node',
+    format: 'cjs',
+    target: 'node20',
+    logLevel: 'silent',
+    plugins: [dependencies],
+  }).then((result) => result.outputFiles[0].text);
+  const bundle = await queryHandlersBundlePromise;
+  const commonJsModule = { exports: {} as unknown };
+  const context = vm.createContext({
+    module: commonJsModule,
+    exports: commonJsModule.exports,
+    console,
+    game: root,
+    __UTILS__: utils,
+    __STRING_FIND__: robloxFind,
+    os: { clock: () => (clock += 0.005) },
+    task: {
+      wait: () => {
+        waitCallCount++;
+        waitCallback?.();
+      },
+    },
+    math: { max: Math.max, min: Math.min },
+    string: {
+      find: robloxFind,
+      sub: (value: string, start: number, finish?: number) => {
+        const from = start > 0 ? start - 1 : value.length + start;
+        const to = finish === undefined ? value.length : (finish > 0 ? finish : value.length + finish + 1);
+        return value.slice(from, to);
+      },
+    },
+    pcall: robloxPcall,
+    error: (value: unknown) => {
+      throw value instanceof Error ? value : new Error(String(value));
+    },
+  });
+  installRobloxStringHelpers(context);
+  vm.runInContext(bundle, context);
+  const loaded = commonJsModule.exports as QueryHandlersModule & { default?: QueryHandlersModule };
+  const handlers = loaded.default ?? loaded;
+  (context as Record<string, unknown>).__HANDLERS__ = handlers;
+
+  return {
+    handlers,
+    splitCalls: () => splitCallCount,
+    waitCalls: () => waitCallCount,
+    onWait: (callback) => { waitCallback = callback; },
+    grepInContext: (request) => {
+      (context as Record<string, unknown>).__REQUEST_JSON__ = JSON.stringify(request);
+      return vm.runInContext('__HANDLERS__.grepScripts(JSON.parse(__REQUEST_JSON__))', context);
+    },
+  };
+}
+
+describe('Studio grep responsiveness', () => {
+  test.each([
+    ['', [''], false],
+    ['\n', [''], true],
+    ['a\n', ['a'], true],
+    ['a\n\n', ['a', ''], true],
+    ['a\r\nb\r', ['a', 'b'], true],
+  ])('keeps splitLines semantics for %j', async (source, expectedLines, expectedTrailingNewline) => {
+    const utils = await loadUtils();
+    const [lines, trailingNewline] = utils.splitLines(source as string);
+    expect([...lines]).toEqual(expectedLines);
+    expect(trailingNewline).toBe(expectedTrailingNewline);
+  });
+
+  test('yields large scans, prefilters misses, and rejects an overlapping grep', async () => {
+    const sources = Array.from({ length: 192 }, (_, index) =>
+      index === 191 ? 'local needle = true' : 'local value = true');
+    const harness = await loadQueryHandlers(sources);
+    let overlappingResult: Record<string, unknown> | undefined;
+    harness.onWait(() => {
+      overlappingResult ??= harness.handlers.grepScripts({ pattern: 'other' });
+    });
+
+    const result = harness.handlers.grepScripts({ pattern: 'needle' });
+    const plainResult = JSON.parse(JSON.stringify(result));
+
+    expect(harness.waitCalls()).toBeGreaterThan(0);
+    expect(overlappingResult).toMatchObject({ error: 'plugin_busy' });
+    expect(harness.splitCalls()).toBe(1);
+    expect(plainResult).toMatchObject({
+      totalMatches: 1,
+      scriptsSearched: 192,
+      scriptsMatched: 1,
+      truncated: false,
+    });
+  });
+
+  test('preserves grep result records while scanning cooperatively', async () => {
+    const harness = await loadQueryHandlers(['before\nlocal needle = true\nafter']);
+
+    const result = JSON.parse(JSON.stringify(harness.handlers.grepScripts({
+      pattern: 'needle',
+      caseSensitive: true,
+      contextLines: 1,
+    })));
+
+    expect(result.results).toEqual([
+      {
+        instancePath: 'game.Script0',
+        name: 'Script0',
+        className: 'ModuleScript',
+        matches: [
+          {
+            line: 2,
+            column: 7,
+            text: 'local needle = true',
+            before: ['before'],
+            after: ['after'],
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('clears the single-flight fence after a search error', async () => {
+    const harness = await loadQueryHandlers(['local needle = true'], { throwOnFirstRead: true });
+
+    expect(() => harness.handlers.grepScripts({ pattern: 'needle' })).toThrow('source read failed');
+
+    const result = harness.handlers.grepScripts({ pattern: 'needle' });
+    expect(harness.splitCalls()).toBe(1);
+    expect(JSON.parse(JSON.stringify(result))).toMatchObject({
+      totalMatches: 1,
+      scriptsMatched: 1,
+    });
+  });
+
+  test('does not apply the literal prefilter to pattern searches', async () => {
+    const harness = await loadQueryHandlers(['local value = true']);
+
+    const result = harness.grepInContext({ pattern: 'needle', usePattern: true });
+
+    expect(harness.splitCalls()).toBe(1);
+    expect(JSON.parse(JSON.stringify(result))).toMatchObject({
+      totalMatches: 0,
+      scriptsSearched: 1,
+    });
+  });
+
+  test('gives grep requests a 120 second bridge timeout', async () => {
+    const bridge = new BridgeService();
+    jest.spyOn(bridge, 'resolveTarget').mockReturnValue({
+      ok: true,
+      mode: 'single',
+      targetInstanceId: 'place:test',
+      targetRole: 'edit',
+    });
+    const sendRequest = jest.spyOn(bridge, 'sendRequest').mockResolvedValue({ results: [] });
+    const tools = new RobloxStudioTools(bridge);
+
+    await tools.grepScripts('needle', {}, 'place:test');
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      '/api/grep-scripts',
+      { pattern: 'needle' },
+      'place:test',
+      'edit',
+      120_000,
+    );
+  });
+});

--- a/packages/core/src/http-server.ts
+++ b/packages/core/src/http-server.ts
@@ -646,10 +646,18 @@ export function createHttpServer(tools: RobloxStudioTools, bridge: BridgeService
 
 
   app.post('/proxy', async (req, res) => {
-    const { endpoint, data, targetInstanceId, targetRole, proxyInstanceId } = req.body;
+    const { endpoint, data, targetInstanceId, targetRole, proxyInstanceId, timeoutMs } = req.body;
 
     if (!endpoint || !targetInstanceId || !targetRole) {
       res.status(400).json({ error: 'endpoint, targetInstanceId, and targetRole are required' });
+      return;
+    }
+
+    if (
+      timeoutMs !== undefined &&
+      (!Number.isInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 300_000)
+    ) {
+      res.status(400).json({ error: 'timeoutMs must be an integer between 1 and 300000' });
       return;
     }
 
@@ -658,7 +666,7 @@ export function createHttpServer(tools: RobloxStudioTools, bridge: BridgeService
     }
 
     try {
-      const response = await bridge.sendRequest(endpoint, data, targetInstanceId, targetRole);
+      const response = await bridge.sendRequest(endpoint, data, targetInstanceId, targetRole, timeoutMs);
       res.json({ response });
     } catch (err: any) {
       res.status(500).json({ error: err.message || 'Proxy request failed' });

--- a/packages/core/src/proxy-bridge-service.ts
+++ b/packages/core/src/proxy-bridge-service.ts
@@ -1,6 +1,8 @@
 import { BridgeService, PluginInstance, PublicPluginInstance, toPublic } from './bridge-service.js';
 import { randomUUID } from 'crypto';
 
+const PROXY_RESPONSE_GRACE_MS = 5_000;
+
 export class ProxyBridgeService extends BridgeService {
   private primaryBaseUrl: string;
   private authToken?: string;
@@ -99,9 +101,16 @@ export class ProxyBridgeService extends BridgeService {
     data: any,
     targetInstanceId: string,
     targetRole: string,
+    timeoutMs = this.proxyRequestTimeout,
   ): Promise<any> {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), this.proxyRequestTimeout);
+    const effectiveTimeoutMs = Math.max(1, timeoutMs);
+    // The primary starts its request timer after this fetch begins. Leave room
+    // for its terminal response to travel back before aborting the proxy hop.
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      effectiveTimeoutMs + PROXY_RESPONSE_GRACE_MS,
+    );
 
     try {
       const response = await fetch(`${this.primaryBaseUrl}/proxy`, {
@@ -113,6 +122,7 @@ export class ProxyBridgeService extends BridgeService {
           targetInstanceId,
           targetRole,
           proxyInstanceId: this.proxyInstanceId,
+          timeoutMs: effectiveTimeoutMs,
         }),
         signal: controller.signal,
       });

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -86,6 +86,7 @@ const MAX_SEARCH_ASSET_DESCRIPTION_LENGTH = 240;
 const ROBLOX_CREATOR_USER_ID = 1;
 const MAX_DEVICE_MATRIX_ENTRIES = 6;
 const MAX_NETWORK_PACKET_LOSS_PERCENT = 0.5;
+const GREP_SCRIPTS_TIMEOUT_MS = 120_000;
 const STUDIO_ASSISTANT_SOURCE_IMAGE_LABEL = 'Studio Assistant Source Image';
 const CREATOR_STORE_SEARCH_TYPES = new Set<string>([
   'Audio',
@@ -1722,7 +1723,7 @@ export class RobloxStudioTools {
     const response = await this._callSingle('/api/grep-scripts', {
       pattern,
       ...(options ?? {}),
-    }, undefined, instance_id);
+    }, undefined, instance_id, GREP_SCRIPTS_TIMEOUT_MS);
     return {
       content: [
         {

--- a/studio-plugin/src/modules/Utils.ts
+++ b/studio-plugin/src/modules/Utils.ts
@@ -183,22 +183,12 @@ function getInstanceByPath(path: string): Instance | undefined {
 function splitLines(source: string): LuaTuple<[string[], boolean]> {
 	const normalized = ((source ?? "") as string).gsub("\r\n", "\n")[0].gsub("\r", "\n")[0];
 	const endsWithNewline = normalized.sub(-1) === "\n";
+	const lines = normalized.split("\n");
 
-	const lines: string[] = [];
-	let start = 1;
-
-	while (true) {
-		const [newlinePos] = string.find(normalized, "\n", start, true);
-		if (newlinePos !== undefined) {
-			lines.push(string.sub(normalized, start, newlinePos - 1));
-			start = newlinePos + 1;
-		} else {
-			const remainder = string.sub(normalized, start);
-			if (remainder !== "" || !endsWithNewline) {
-				lines.push(remainder);
-			}
-			break;
-		}
+	// split() includes a final empty field for a trailing newline. Keep the
+	// existing splitLines contract, which tracks that newline separately.
+	if (endsWithNewline && lines[lines.size() - 1] === "") {
+		lines.pop();
 	}
 
 	if (lines.size() === 0) {

--- a/studio-plugin/src/modules/handlers/QueryHandlers.ts
+++ b/studio-plugin/src/modules/handlers/QueryHandlers.ts
@@ -557,7 +557,27 @@ function findFirstPattern(line: string, alternatives: string[]): [number | undef
 	return [bestStart, bestEnd];
 }
 
-function grepScripts(requestData: Record<string, unknown>) {
+const GREP_CLOCK_CHECK_INTERVAL = 64;
+const GREP_MAX_COOPERATIVE_SLICE_SECONDS = 0.004;
+let grepScriptsInFlight = false;
+
+function createGrepCheckpoint(): () => void {
+	let operationsSinceClockCheck = 0;
+	let sliceStartedAt = os.clock();
+
+	return () => {
+		operationsSinceClockCheck++;
+		if (operationsSinceClockCheck < GREP_CLOCK_CHECK_INTERVAL) return;
+
+		operationsSinceClockCheck = 0;
+		if (os.clock() - sliceStartedAt < GREP_MAX_COOPERATIVE_SLICE_SECONDS) return;
+
+		task.wait();
+		sliceStartedAt = os.clock();
+	};
+}
+
+function runGrepScripts(requestData: Record<string, unknown>) {
 	const pattern = requestData.pattern as string;
 	if (!pattern) return { error: "pattern is required" };
 
@@ -583,6 +603,11 @@ function grepScripts(requestData: Record<string, unknown>) {
 	const searchPattern = caseSensitive ? pattern : pattern.lower();
 	// Pre-split top-level "|" alternation once (pattern mode only).
 	const patternAlternatives = usePattern ? splitLuaAlternation(searchPattern) : undefined;
+	function sourceCanMatch(source: string): boolean {
+		if (usePattern) return true;
+		const candidate = caseSensitive ? source : source.lower();
+		return string.find(candidate, searchPattern, 1, true)[0] !== undefined;
+	}
 
 	interface LineMatch {
 		line: number;
@@ -604,9 +629,11 @@ function grepScripts(requestData: Record<string, unknown>) {
 	let totalMatches = 0;
 	let scriptsSearched = 0;
 	let hitLimit = false;
+	const checkpoint = createGrepCheckpoint();
 
 	function searchInstance(instance: Instance) {
 		if (hitLimit) return;
+		checkpoint();
 
 		if (instance.IsA("LuaSourceContainer")) {
 			// Apply class filter
@@ -616,73 +643,79 @@ function grepScripts(requestData: Record<string, unknown>) {
 
 			scriptsSearched++;
 			const source = readScriptSource(instance);
-			const [lines] = Utils.splitLines(source);
-			const scriptMatches: LineMatch[] = [];
-			let scriptMatchCount = 0;
 
-			for (let i = 0; i < lines.size(); i++) {
-				if (hitLimit) break;
-				if (maxResultsPerScript > 0 && scriptMatchCount >= maxResultsPerScript) break;
+			if (sourceCanMatch(source)) {
+				checkpoint();
+				const [lines] = Utils.splitLines(source);
+				checkpoint();
+				const scriptMatches: LineMatch[] = [];
+				let scriptMatchCount = 0;
 
-				const line = lines[i];
-				const searchLine = caseSensitive ? line : line.lower();
+				for (let i = 0; i < lines.size(); i++) {
+					checkpoint();
+					if (hitLimit) break;
+					if (maxResultsPerScript > 0 && scriptMatchCount >= maxResultsPerScript) break;
 
-				let matchStart: number | undefined;
-				let matchEnd: number | undefined;
+					const line = lines[i];
+					const searchLine = caseSensitive ? line : line.lower();
 
-				if (usePattern) {
-					[matchStart, matchEnd] = findFirstPattern(searchLine, patternAlternatives!);
-				} else {
-					[matchStart, matchEnd] = string.find(searchLine, searchPattern, 1, true);
-				}
+					let matchStart: number | undefined;
+					let matchEnd: number | undefined;
 
-				if (matchStart !== undefined) {
-					scriptMatchCount++;
-					totalMatches++;
-
-					if (totalMatches > maxResults) {
-						hitLimit = true;
-						break;
+					if (usePattern) {
+						[matchStart, matchEnd] = findFirstPattern(searchLine, patternAlternatives!);
+					} else {
+						[matchStart, matchEnd] = string.find(searchLine, searchPattern, 1, true);
 					}
 
-					if (!filesOnly) {
-						// Gather context lines
-						const before: string[] = [];
-						const after: string[] = [];
+					if (matchStart !== undefined) {
+						scriptMatchCount++;
+						totalMatches++;
 
-						if (contextLines > 0) {
-							const beforeStart = math.max(0, i - contextLines);
-							for (let j = beforeStart; j < i; j++) {
-								before.push(lines[j]);
-							}
-							const afterEnd = math.min(lines.size() - 1, i + contextLines);
-							for (let j = i + 1; j <= afterEnd; j++) {
-								after.push(lines[j]);
-							}
+						if (totalMatches > maxResults) {
+							hitLimit = true;
+							break;
 						}
 
-						scriptMatches.push({
-							line: i + 1, // 1-indexed
-							column: matchStart,
-							text: line,
-							before,
-							after,
-						});
+						if (!filesOnly) {
+							// Gather context lines
+							const before: string[] = [];
+							const after: string[] = [];
+
+							if (contextLines > 0) {
+								const beforeStart = math.max(0, i - contextLines);
+								for (let j = beforeStart; j < i; j++) {
+									before.push(lines[j]);
+								}
+								const afterEnd = math.min(lines.size() - 1, i + contextLines);
+								for (let j = i + 1; j <= afterEnd; j++) {
+									after.push(lines[j]);
+								}
+							}
+
+							scriptMatches.push({
+								line: i + 1, // 1-indexed
+								column: matchStart,
+								text: line,
+								before,
+								after,
+							});
+						}
 					}
 				}
-			}
 
-			if (scriptMatchCount > 0) {
-				const scriptResult: ScriptResult = {
-					instancePath: getInstancePath(instance),
-					name: instance.Name,
-					className: instance.ClassName,
-					matches: scriptMatches,
-				};
-				if (instance.IsA("BaseScript")) {
-					scriptResult.enabled = instance.Enabled;
+				if (scriptMatchCount > 0) {
+					const scriptResult: ScriptResult = {
+						instancePath: getInstancePath(instance),
+						name: instance.Name,
+						className: instance.ClassName,
+						matches: scriptMatches,
+					};
+					if (instance.IsA("BaseScript")) {
+						scriptResult.enabled = instance.Enabled;
+					}
+					results.push(scriptResult);
 				}
-				results.push(scriptResult);
 			}
 		}
 
@@ -703,6 +736,21 @@ function grepScripts(requestData: Record<string, unknown>) {
 		truncated: hitLimit,
 		options: { caseSensitive, contextLines, usePattern, filesOnly, maxResults, maxResultsPerScript },
 	};
+}
+
+function grepScripts(requestData: Record<string, unknown>) {
+	if (grepScriptsInFlight) {
+		return {
+			error: "plugin_busy",
+			message: "Another grep_scripts request is already running in this Studio DataModel. Retry after it completes.",
+		};
+	}
+
+	grepScriptsInFlight = true;
+	const [ok, result] = pcall(() => runGrepScripts(requestData));
+	grepScriptsInFlight = false;
+	if (!ok) error(result, 0);
+	return result;
 }
 
 export = {


### PR DESCRIPTION
`grep_scripts` can keep the Studio plugin VM busy for long stretches in large places. With several MCP clients connected, overlapping scans can pile up until Studio reports the plugin as unresponsive. The stacks I captured consistently ended in `Utils.splitLines -> searchInstance -> grepScripts`.

This keeps the search path cooperative without changing the result shape:

- yield during recursive traversal and line scanning
- allow one grep per DataModel at a time; overlapping requests return `plugin_busy`
- skip line splitting when a literal query cannot match, and use Luau's built-in splitter when it can
- give grep up to 120 seconds, including proxy mode, with a short proxy response grace

Verification:

- `npm run typecheck`
- `npm run build`
- `npm run build:plugin:artifact`
- `npm test -w packages/core -- --runInBand studio-grep-responsiveness.test.ts proxy-bridge-service.test.ts http-server.test.ts`