### PR TITLE
Fix play-server event stream leaks across play cycles

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:studio:runner": "npm run build:plugin:artifact && node tests/run-with-test-port.mjs tests/run-all.mjs --managed",
     "test:studio:parallel": "npm run build:plugin:artifact && node tests/parallel-studio-isolation-smoke.mjs",
     "test:studio:sse-capacity": "npm run build:plugin:artifact && node tests/sse-multi-studio-capacity.mjs",
+    "test:studio:event-stream-cycles": "npm run build:plugin:artifact && node tests/run-with-test-port.mjs tests/run-all.mjs --managed --test play-cycle-event-stream-regression.mjs",
     "test:e2e:wsl-process-identity": "node tests/run-with-test-port.mjs tests/wsl-process-identity-launch.mjs",
     "test:e2e:lifecycle": "npm run test:e2e:wsl-process-identity && node tests/run-with-test-port.mjs tests/studio-lifecycle-regressions.mjs",
     "test:studio:tools": "node tests/run-with-test-port.mjs tests/studio-tooling-smoke.mjs",

--- a/studio-plugin/src/modules/StopPlayMonitor.ts
+++ b/studio-plugin/src/modules/StopPlayMonitor.ts
@@ -44,6 +44,7 @@ const REQUEST_TTL_SEC = 12.0;
 
 let pluginRef: Plugin | undefined;
 let endTestIssued = false;
+let transportLifecycle: StopTransportLifecycle | undefined;
 
 interface StopPayload {
 	kind?: string;
@@ -63,6 +64,11 @@ interface StopConsumptionResult {
 	ok: boolean;
 	consumed: boolean;
 	error?: string;
+}
+
+interface StopTransportLifecycle {
+	beforeEndTest: () => void;
+	afterEndTestFailure: () => void;
 }
 
 function init(p: Plugin): void {
@@ -177,14 +183,28 @@ function handleStopRequest(key: string, request: StopPayload): void {
 	}
 
 	endTestIssued = true;
+	const lifecycle = transportLifecycle;
+	if (lifecycle !== undefined) {
+		const [closeOk, closeError] = pcall(lifecycle.beforeEndTest);
+		if (!closeOk) {
+			warn(`[robloxstudio-mcp] Failed to close the play-server transport before EndTest: ${tostring(closeError)}`);
+		}
+	}
 	const [endOk, endErr] = pcall(() => StudioTestService.EndTest("stopped_by_mcp"));
 	writeResult(key, request, endOk, endOk ? undefined : tostring(endErr));
 	if (!endOk) {
 		endTestIssued = false;
+		if (lifecycle !== undefined) {
+			const [restoreOk, restoreError] = pcall(lifecycle.afterEndTestFailure);
+			if (!restoreOk) {
+				warn(`[robloxstudio-mcp] Failed to restore the play-server transport after EndTest failed: ${tostring(restoreError)}`);
+			}
+		}
 	}
 }
 
-function startMonitor(): void {
+function startMonitor(lifecycle: StopTransportLifecycle): void {
+	transportLifecycle = lifecycle;
 	if (!pluginRef) {
 		warn("[robloxstudio-mcp] StopPlayMonitor.startMonitor called before init; skipping");
 		return;

--- a/studio-plugin/src/modules/StudioEventStream.ts
+++ b/studio-plugin/src/modules/StudioEventStream.ts
@@ -48,6 +48,7 @@ interface InFlightRequest {
 
 let options: StudioEventStreamOptions | undefined;
 let active = false;
+let shutdownSuspended = false;
 let generation = 0;
 let reconnectAttempt = 0;
 let streamClient: WebStreamClient | undefined;
@@ -148,6 +149,17 @@ function closeCurrentStream(): void {
 	if (current !== undefined) {
 		pcall(() => current.Close());
 	}
+}
+
+function disconnectSession(currentOptions: StudioEventStreamOptions): void {
+	pcall(() =>
+		HttpService.RequestAsync({
+			Url: `${currentOptions.serverUrl}/disconnect`,
+			Method: "POST",
+			Headers: { "Content-Type": "application/json" },
+			Body: HttpService.JSONEncode({ pluginSessionId: PluginSession.id, timestamp: tick() }),
+		}),
+	);
 }
 
 function responseRetryDelay(attempt: number): number {
@@ -555,9 +567,10 @@ function connect(expectedGeneration: number): void {
 }
 
 function start(newOptions: StudioEventStreamOptions): void {
-	if (active) stop();
+	if (active || shutdownSuspended) stop();
 	options = newOptions;
 	active = true;
+	shutdownSuspended = false;
 	reconnectAttempt = 0;
 	generation++;
 	connect(generation);
@@ -571,10 +584,35 @@ function refresh(): void {
 	connect(generation);
 }
 
+// EndTest can tear down a play DataModel without giving Plugin.Unloading a
+// usable execution window. Release the native WebStreamClient before the
+// yielding unregister request, but retain local request state and connection
+// options so a failed EndTest can register again and reconnect.
+function suspendForShutdown(): void {
+	const currentOptions = options;
+	if (!active || currentOptions === undefined) return;
+	active = false;
+	shutdownSuspended = true;
+	generation++;
+	reconnectAttempt = 0;
+	closeCurrentStream();
+	disconnectSession(currentOptions);
+}
+
+function resumeAfterShutdownFailure(): void {
+	if (!shutdownSuspended || options === undefined) return;
+	shutdownSuspended = false;
+	active = true;
+	generation++;
+	reconnectAttempt = 0;
+	connect(generation);
+}
+
 function stop(): void {
-	if (!active) return;
+	if (!active && !shutdownSuspended) return;
 	const currentOptions = options;
 	active = false;
+	shutdownSuspended = false;
 	generation++;
 	for (const [, inFlight] of inFlightRequests) {
 		inFlight.cancelled = true;
@@ -586,19 +624,14 @@ function stop(): void {
 	options = undefined;
 	reconnectAttempt = 0;
 	if (currentOptions !== undefined) {
-		pcall(() =>
-			HttpService.RequestAsync({
-				Url: `${currentOptions.serverUrl}/disconnect`,
-				Method: "POST",
-				Headers: { "Content-Type": "application/json" },
-				Body: HttpService.JSONEncode({ pluginSessionId: PluginSession.id, timestamp: tick() }),
-			}),
-		);
+		disconnectSession(currentOptions);
 	}
 }
 
 export = {
 	start,
 	refresh,
+	suspendForShutdown,
+	resumeAfterShutdownFailure,
 	stop,
 };

--- a/studio-plugin/src/server/index.server.ts
+++ b/studio-plugin/src/server/index.server.ts
@@ -6,6 +6,7 @@ import ServerUrlSettings from "../modules/ServerUrlSettings";
 import { cleanupEditBridgeArtifacts, ensureRuntimeBridgeInstalled } from "../modules/EvalBridges";
 import RuntimeLogBuffer from "../modules/RuntimeLogBuffer";
 import StopPlayMonitor from "../modules/StopPlayMonitor";
+import StudioEventStream from "../modules/StudioEventStream";
 import BreakpointHandlers from "../modules/handlers/BreakpointHandlers";
 import * as RenderMonitor from "../modules/RenderMonitor";
 
@@ -26,8 +27,10 @@ StopPlayMonitor.init(plugin);
 BreakpointHandlers.init(plugin);
 ServerUrlSettings.init(plugin);
 
+const startupRole = ClientBroker.forkRole();
+
 function applyRememberedServerUrl(): void {
-	if (ClientBroker.forkRole() === "client") return;
+	if (startupRole === "client") return;
 
 	const rememberedServerUrl = ServerUrlSettings.readServerUrl();
 	if (rememberedServerUrl === undefined) return;
@@ -40,6 +43,16 @@ function applyRememberedServerUrl(): void {
 }
 
 applyRememberedServerUrl();
+
+// Play DataModels do not reliably fire Plugin.Unloading before Studio tears
+// down their VM. Close the persistent WebStreamClient while BindToClose still
+// gives this server peer a live execution context; otherwise each play cycle
+// can retain one native event stream until Studio itself is restarted. The
+// transport releases that native stream before yielding to unregister the
+// logical server peer.
+if (startupRole === "server") {
+	game.BindToClose(StudioEventStream.suspendForShutdown);
+}
 
 UI.init(plugin);
 const elements = UI.getElements();
@@ -92,7 +105,7 @@ task.delay(TOOLBAR_REGISTRATION_DELAY_SECONDS, registerToolbarButton);
 // play peers' plugin instances load without ever registering. Run after a
 // short delay so the UI/State have a chance to initialize first.
 task.delay(2, () => {
-	const role = ClientBroker.forkRole();
+	const role = startupRole;
 	if (role === "edit") {
 		cleanupEditBridgeArtifacts();
 	} else {
@@ -128,7 +141,10 @@ task.delay(2, () => {
 		// The play-server DM is the only one where StudioTestService:EndTest is
 		// legal, so the stop-play monitor lives here. It consumes tokenized
 		// stop requests from plugin settings and acknowledges EndTest results.
-		StopPlayMonitor.startMonitor();
+		StopPlayMonitor.startMonitor({
+			beforeEndTest: StudioEventStream.suspendForShutdown,
+			afterEndTestFailure: StudioEventStream.resumeAfterShutdownFailure,
+		});
 	} else if (role === "client") {
 		ClientBroker.setupClientBroker();
 	}

--- a/tests/play-cycle-event-stream-regression.mjs
+++ b/tests/play-cycle-event-stream-regression.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import { setTimeout as delay } from 'node:timers/promises';
+import {
+  BASE_PORT,
+  McpClient,
+  assert,
+  runTest,
+  safeStopPlaytest,
+  startPlaytestAndWait,
+  waitForEditPeer,
+} from './lib/mcp-client.mjs';
+import { callMcpHttpTool } from './lib/mcp-http-client.mjs';
+
+const PLAY_CYCLES = Number.parseInt(process.env.RSMCP_PLAY_CYCLES ?? '8', 10);
+if (!Number.isSafeInteger(PLAY_CYCLES) || PLAY_CYCLES < 1 || PLAY_CYCLES > 100) {
+  throw new Error('RSMCP_PLAY_CYCLES must be an integer from 1 through 100');
+}
+const RUNTIME_DRAIN_TIMEOUT_MS = 30_000;
+const EDIT_MODE_SETTLE_TIMEOUT_MS = 15_000;
+const HTTP_ROUTED_TOOLS = new Set([
+  'eval_server_runtime',
+  'execute_luau',
+  'solo_playtest',
+]);
+
+function httpToolClient() {
+  return {
+    callTool(name, args = {}, timeoutMs = 30_000) {
+      const instanceId = process.env.MCP_INSTANCE_ID;
+      const routedArgs = instanceId && HTTP_ROUTED_TOOLS.has(name) && args.instance_id === undefined
+        ? { ...args, instance_id: instanceId }
+        : args;
+      return callMcpHttpTool(name, routedArgs, {
+        port: BASE_PORT,
+        env: process.env,
+        timeoutMs,
+      });
+    },
+  };
+}
+
+function rolesForInstance(connected) {
+  const expectedInstanceId = process.env.MCP_INSTANCE_ID;
+  return (connected.instances ?? [])
+    .filter((instance) => !expectedInstanceId || instance.id === expectedInstanceId || instance.instanceId === expectedInstanceId)
+    .flatMap((instance) => instance.roles ?? (instance.role ? [instance.role] : []));
+}
+
+async function waitForRuntimePeersToDrain(client) {
+  const deadline = Date.now() + RUNTIME_DRAIN_TIMEOUT_MS;
+  let lastRoles = [];
+  while (Date.now() < deadline) {
+    const connected = await client.callTool('get_connected_instances', {});
+    lastRoles = rolesForInstance(connected);
+    if (!lastRoles.some((role) => role === 'server' || role.startsWith('client-'))) return;
+    await delay(250);
+  }
+  throw new Error(`Runtime peers did not drain after stop. Last roles: ${JSON.stringify(lastRoles)}`);
+}
+
+async function waitForEditModeToSettle(client) {
+  const deadline = Date.now() + EDIT_MODE_SETTLE_TIMEOUT_MS;
+  let lastState;
+  while (Date.now() < deadline) {
+    try {
+      const result = await client.callTool('execute_luau', {
+        target: 'edit',
+        code: 'return tostring(game:GetService("StudioTestService").EditModeActive)',
+      }, 5_000);
+      lastState = result.returnValue;
+      if (result.success === true && result.returnValue === 'true') return;
+    } catch (error) {
+      lastState = error instanceof Error ? error.message : String(error);
+    }
+    await delay(100);
+  }
+  throw new Error(`Studio did not settle in edit mode after stop. Last state: ${JSON.stringify(lastState)}`);
+}
+
+async function activeEventStreamCount() {
+  const response = await fetch(`http://127.0.0.1:${BASE_PORT}/health`);
+  if (!response.ok) throw new Error(`/health returned HTTP ${response.status}`);
+  const health = await response.json();
+  return health.activeEventStreams;
+}
+
+async function assertEditStreamResponds(client, cycle) {
+  const marker = `event-stream-cycle-${cycle}`;
+  const result = await client.callTool('execute_luau', {
+    target: 'edit',
+    code: `return ${JSON.stringify(marker)}`,
+  });
+  assert(
+    result.success === true && result.returnValue === marker,
+    `cycle ${cycle}: edit event stream responds after runtime teardown`,
+  );
+}
+
+await runTest('event stream survives repeated play cycles', async ({ track }) => {
+  // Keep a normal MCP client connected while a second authenticated client
+  // drives POST /mcp/<tool>, matching the original report's topology.
+  const mcpClient = track(new McpClient('play-cycle-event-stream'));
+  await mcpClient.start();
+  await mcpClient.initialize();
+  const client = httpToolClient();
+  await waitForEditPeer(client, { timeoutMs: 120_000 });
+
+  let playRunning = false;
+
+  try {
+    assert(await activeEventStreamCount() === 1, 'baseline has only the edit event stream');
+
+    for (let cycle = 1; cycle <= PLAY_CYCLES; cycle += 1) {
+      playRunning = true;
+      await startPlaytestAndWait(client, { timeoutSec: 45, pollMs: 250 });
+      assert(await activeEventStreamCount() === 2, `cycle ${cycle}: edit and server event streams are active`);
+
+      const runtimeMarker = `runtime-cycle-${cycle}`;
+      const runtime = await client.callTool('eval_server_runtime', {
+        code: `return { marker = ${JSON.stringify(runtimeMarker)} }`,
+      });
+      const runtimeResult = JSON.parse(runtime.result);
+      assert(
+        runtime.ok === true && runtime.bridge === 'ok' && runtimeResult.marker === runtimeMarker,
+        `cycle ${cycle}: server eval crosses the runtime event stream`,
+      );
+
+      const stopped = await client.callTool('solo_playtest', { action: 'stop' }, 45_000);
+      assert(stopped.success === true, `cycle ${cycle}: playtest stops cleanly`);
+      assert(
+        await activeEventStreamCount() === 1,
+        `cycle ${cycle}: server event stream is released before stop returns`,
+      );
+      playRunning = false;
+      await waitForRuntimePeersToDrain(client);
+      await waitForEditModeToSettle(client);
+      assert(true, `cycle ${cycle}: Studio settles fully in edit mode`);
+
+      assert(await activeEventStreamCount() === 1, `cycle ${cycle}: server event stream is released`);
+      await assertEditStreamResponds(client, cycle);
+    }
+  } finally {
+    if (playRunning) await safeStopPlaytest(client);
+  }
+}).then((ok) => process.exit(ok ? 0 : 1));

--- a/tests/run-all.mjs
+++ b/tests/run-all.mjs
@@ -37,6 +37,7 @@ const FULL_TESTS = [
   'eval-bridge-error-preservation.mjs',
   'eval-context-routing.mjs',
   'runtime-bridge-lifecycle.mjs',
+  'play-cycle-event-stream-regression.mjs',
   'micro-profiler-responsiveness.mjs',
   'studio-grep-responsiveness.mjs',
   'execute-luau-error-preservation.mjs',
@@ -52,7 +53,15 @@ const FEATURE_TESTS = [
   'micro-profiler-responsiveness.mjs',
 ];
 const featureSmoke = process.argv.includes('--smoke');
-const TESTS = featureSmoke ? FEATURE_TESTS : FULL_TESTS;
+const requestedTestIndex = process.argv.indexOf('--test');
+const requestedTest = requestedTestIndex === -1 ? undefined : process.argv[requestedTestIndex + 1];
+if (requestedTestIndex !== -1 && !requestedTest) {
+  throw new Error('--test requires a test filename');
+}
+if (requestedTest && !FULL_TESTS.includes(requestedTest)) {
+  throw new Error(`Unknown Studio test ${JSON.stringify(requestedTest)}`);
+}
+const TESTS = requestedTest ? [requestedTest] : (featureSmoke ? FEATURE_TESTS : FULL_TESTS);
 
 // Studio takes a few seconds to fully tear down a play DM after StudioTestService:EndTest.
 // Without a gap, the next test's solo_playtest start collides with the previous test's


### PR DESCRIPTION
## Summary
- close the play-server WebStreamClient before StudioTestService:EndTest and unregister its bridge session
- restore the suspended transport if EndTest fails, without losing client proxy registrations
- add a BindToClose fallback for play-server DataModels
- add an eight-cycle dual-client Studio regression with stream-count and edit-mode-settle assertions

## Verification
- `npm run test:e2e`
- `npm run test:studio:event-stream-cycles`
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:plugin`

Fixes #66