### PR TITLE
chore: prepare v3.0.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,6 @@ claude mcp add robloxstudio-inspector -- npx -y @chrrxs/robloxstudio-mcp-inspect
 ---
 
 <!-- VERSION_LINE -->
-**v3.0.4**
+**v3.0.5**
 
 [Report Issues](https://github.com/chrrxs/robloxstudio-mcp/issues) · MIT Licensed · Based on [boshyxd/robloxstudio-mcp](https://github.com/boshyxd/robloxstudio-mcp) v2.7.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chrrxs/robloxstudio-mcp-monorepo",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chrrxs/robloxstudio-mcp-monorepo",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "workspaces": [
         "packages/*"
       ],
@@ -8203,7 +8203,7 @@
     },
     "packages/core": {
       "name": "@chrrxs/robloxstudio-mcp-core",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "dependencies": {
         "fzstd": "^0.1.1",
         "saxes": "^6.0.0"
@@ -8231,7 +8231,7 @@
     },
     "packages/robloxstudio-mcp": {
       "name": "@chrrxs/robloxstudio-mcp",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",
@@ -8252,7 +8252,7 @@
     },
     "packages/robloxstudio-mcp-inspector": {
       "name": "@chrrxs/robloxstudio-mcp-inspector",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrrxs/robloxstudio-mcp-monorepo",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrrxs/robloxstudio-mcp-core",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/robloxstudio-mcp-inspector/package.json
+++ b/packages/robloxstudio-mcp-inspector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrrxs/robloxstudio-mcp-inspector",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "DataModel read-only MCP server for inspecting and debugging Roblox Studio from AI coding tools",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/robloxstudio-mcp/package.json
+++ b/packages/robloxstudio-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrrxs/robloxstudio-mcp",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "MCP server for testing, debugging, and controlling Roblox Studio from AI coding tools",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump the monorepo and publishable packages from 3.0.4 to 3.0.5
- update the lockfile workspace versions and README release marker

## Verification
- `npm run test:e2e:full` (passed in 368s)