### PR TITLE
feat(studio): discover Studio installs from third-party launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ screenshots, memory reports, and profiler captures from each peer.
 
 - Start, inspect, and stop solo or multi-client sessions with `solo_playtest` and `multiplayer_playtest`.
 - Open or close Studio windows with `manage_instance`. It can launch a baseplate, a local place file, a published place, or an older place revision.
+- Launches find Studio in the official install tree and in third-party launcher trees such as Roblox Mod Loader. See [which Studio gets launched](docs/configuration.md#which-studio-gets-launched).
 
 ### Find performance problems
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,7 +60,37 @@ Studio to load the matching bundled plugin.
 | `ROBLOX_STUDIO_ALLOWED_ORIGINS` | None | Comma-separated browser origins allowed to call the HTTP API cross-origin. |
 | `ROBLOX_OPEN_CLOUD_API_KEY` | None | Roblox Open Cloud key used by features such as audio preview and place version access. Required permissions depend on the tool. |
 | `MCP_PLUGINS_DIR` | Platform Studio Plugins folder | Override the destination used by plugin installation. |
+| `ROBLOX_STUDIO_EXE` | Auto-discovered | Exact Studio executable used by `manage_instance action=launch`. |
+| `ROBLOX_STUDIO_SOURCE` | `auto` | Restrict auto-discovery to one install source: `official`, `rml`, or `custom`. |
+| `ROBLOX_STUDIO_SEARCH_ROOTS` | None | Extra Studio install roots, separated by `;`. Each is scanned for `version-*/RobloxStudioBeta.exe` and for a `RobloxStudioBeta.exe` directly inside it. |
 
 Creator Store audio preview requires `asset:read` permission. See
 [Creator Store assets](creator-store-assets.md) for its download and validation
 behavior.
+
+## Which Studio gets launched
+
+`manage_instance action=launch` discovers Studio in both the official install
+tree (`%LOCALAPPDATA%\Roblox\Versions`) and third-party launcher trees. The
+Roblox Mod Loader launcher, which installs each Studio build under
+`%APPDATA%\com.revolution.rml-launcher\studio\versions\version-<hash>`, is
+recognized.
+
+That launcher also records the instance it opens by default in
+`studio/settings.json` as `"defaultInstallationId": "<source>:<version-folder>"`.
+The source decides which tree the default lives in: `managed` is the launcher's
+own tree, `roblox-official` is `%LOCALAPPDATA%\Roblox\Versions`. Only builds
+found under the matching root are treated as the launcher default.
+
+Selection order:
+
+1. `studio_executable` on the launch request.
+2. `ROBLOX_STUDIO_EXE`.
+3. The build a launcher declares as its default.
+4. The most recently modified `RobloxStudioBeta.exe` across every searched root.
+
+Run `manage_instance action=list_studio_installations` to see every install
+found, which one a launch would use, and why. Any other launcher can be added
+with `ROBLOX_STUDIO_SEARCH_ROOTS`; `ROBLOX_STUDIO_SOURCE=official` restores
+official-only discovery.
+

--- a/packages/core/src/__tests__/studio-installations.test.ts
+++ b/packages/core/src/__tests__/studio-installations.test.ts
@@ -1,0 +1,234 @@
+import * as path from 'path';
+import {
+  RML_LAUNCHER_DIRECTORY,
+  STUDIO_EXECUTABLE_NAME,
+  discoverStudioInstallations,
+  parseStudioInstallationSource,
+  parseStudioSearchRoots,
+  readRmlDefaultInstallation,
+  selectStudioInstallation,
+  type StudioInstallationFs,
+} from '../studio-installations.js';
+
+const LOCAL_APP_DATA = path.join('C:', 'Users', 'dev', 'AppData', 'Local');
+const ROAMING_APP_DATA = path.join('C:', 'Users', 'dev', 'AppData', 'Roaming');
+const OFFICIAL_ROOT = path.join(LOCAL_APP_DATA, 'Roblox', 'Versions');
+const RML_STUDIO = path.join(ROAMING_APP_DATA, RML_LAUNCHER_DIRECTORY, 'studio');
+const RML_ROOT = path.join(RML_STUDIO, 'versions');
+
+interface FakeTree {
+  /** Executable path -> mtime in ms. */
+  files: Record<string, number>;
+  /** File path -> contents. */
+  texts?: Record<string, string>;
+}
+
+function fakeFs(tree: FakeTree): StudioInstallationFs {
+  const texts = tree.texts ?? {};
+  const directories = new Set<string>();
+  for (const file of [...Object.keys(tree.files), ...Object.keys(texts)]) {
+    for (let parent = path.dirname(file); parent !== path.dirname(parent); parent = path.dirname(parent)) {
+      directories.add(parent);
+    }
+  }
+
+  return {
+    existsSync: (target) =>
+      target in tree.files || target in texts || directories.has(target),
+    readdirSync: (target) => {
+      if (!directories.has(target)) throw new Error(`ENOENT: ${target}`);
+      const children = new Set<string>();
+      for (const file of [...Object.keys(tree.files), ...Object.keys(texts)]) {
+        if (path.dirname(file) === target) children.add(path.basename(file));
+        else if (file.startsWith(`${target}${path.sep}`)) {
+          children.add(file.slice(target.length + 1).split(path.sep)[0]);
+        }
+      }
+      return [...children];
+    },
+    statSync: (target) => {
+      const mtimeMs = tree.files[target];
+      if (mtimeMs === undefined) throw new Error(`ENOENT: ${target}`);
+      return { mtimeMs };
+    },
+    readFileSync: (target) => {
+      const contents = texts[target];
+      if (contents === undefined) throw new Error(`ENOENT: ${target}`);
+      return contents;
+    },
+  };
+}
+
+function studioExe(root: string, versionFolder: string): string {
+  return path.join(root, versionFolder, STUDIO_EXECUTABLE_NAME);
+}
+
+describe('studio installation discovery', () => {
+  const previousSource = process.env.ROBLOX_STUDIO_SOURCE;
+
+  afterEach(() => {
+    if (previousSource === undefined) delete process.env.ROBLOX_STUDIO_SOURCE;
+    else process.env.ROBLOX_STUDIO_SOURCE = previousSource;
+  });
+
+  test('official install alone resolves the most recently modified build', () => {
+    const fs = fakeFs({
+      files: {
+        [studioExe(OFFICIAL_ROOT, 'version-aaa')]: 1_000,
+        [studioExe(OFFICIAL_ROOT, 'version-bbb')]: 5_000,
+      },
+    });
+
+    const installations = discoverStudioInstallations({ localAppData: LOCAL_APP_DATA }, fs);
+
+    expect(installations.map((entry) => entry.versionFolder)).toEqual(['version-bbb', 'version-aaa']);
+    expect(selectStudioInstallation(installations)?.executable).toBe(studioExe(OFFICIAL_ROOT, 'version-bbb'));
+  });
+
+  test('a mod loader install is discovered even though it lives outside LOCALAPPDATA', () => {
+    const fs = fakeFs({
+      files: { [studioExe(RML_ROOT, 'version-ccc')]: 4_000 },
+    });
+
+    const installations = discoverStudioInstallations(
+      { localAppData: LOCAL_APP_DATA, roamingAppData: ROAMING_APP_DATA },
+      fs,
+    );
+
+    expect(installations).toHaveLength(1);
+    expect(installations[0]).toMatchObject({
+      executable: studioExe(RML_ROOT, 'version-ccc'),
+      source: 'rml',
+      launcherDefault: false,
+    });
+  });
+
+  test('the launcher-declared default outranks a newer official build', () => {
+    const fs = fakeFs({
+      files: {
+        [studioExe(OFFICIAL_ROOT, 'version-aaa')]: 9_000,
+        [studioExe(RML_ROOT, 'version-ccc')]: 1_000,
+        [studioExe(RML_ROOT, 'version-ddd')]: 2_000,
+      },
+      texts: {
+        [path.join(RML_STUDIO, 'settings.json')]: '{"defaultInstallationId":"managed:version-ccc"}',
+      },
+    });
+
+    const selected = selectStudioInstallation(
+      discoverStudioInstallations({ localAppData: LOCAL_APP_DATA, roamingAppData: ROAMING_APP_DATA }, fs),
+    );
+
+    expect(selected?.executable).toBe(studioExe(RML_ROOT, 'version-ccc'));
+    expect(selected?.launcherDefault).toBe(true);
+  });
+
+  test('a launcher default pointing at the official tree selects the official build', () => {
+    const fs = fakeFs({
+      files: {
+        [studioExe(OFFICIAL_ROOT, 'version-aaa')]: 1_000,
+        [studioExe(RML_ROOT, 'version-ccc')]: 9_000,
+      },
+      texts: {
+        [path.join(RML_STUDIO, 'settings.json')]: '{"defaultInstallationId":"roblox-official:version-aaa"}',
+      },
+    });
+
+    const selected = selectStudioInstallation(
+      discoverStudioInstallations({ localAppData: LOCAL_APP_DATA, roamingAppData: ROAMING_APP_DATA }, fs),
+    );
+
+    expect(selected).toMatchObject({
+      executable: studioExe(OFFICIAL_ROOT, 'version-aaa'),
+      source: 'official',
+      launcherDefault: true,
+    });
+  });
+
+  test('a source preference restores single-tree selection', () => {
+    const fs = fakeFs({
+      files: {
+        [studioExe(OFFICIAL_ROOT, 'version-aaa')]: 9_000,
+        [studioExe(RML_ROOT, 'version-ccc')]: 1_000,
+      },
+      texts: {
+        [path.join(RML_STUDIO, 'settings.json')]: '{"defaultInstallationId":"managed:version-ccc"}',
+      },
+    });
+    const installations = discoverStudioInstallations(
+      { localAppData: LOCAL_APP_DATA, roamingAppData: ROAMING_APP_DATA },
+      fs,
+    );
+
+    expect(selectStudioInstallation(installations, 'official')?.executable)
+      .toBe(studioExe(OFFICIAL_ROOT, 'version-aaa'));
+    expect(selectStudioInstallation(installations, 'custom')).toBeUndefined();
+  });
+
+  test('extra roots contribute both versioned and flat layouts', () => {
+    const extraRoot = path.join('D:', 'Studios');
+    const fs = fakeFs({
+      files: {
+        [path.join(extraRoot, STUDIO_EXECUTABLE_NAME)]: 3_000,
+        [studioExe(extraRoot, 'version-eee')]: 7_000,
+      },
+    });
+
+    const installations = discoverStudioInstallations({ extraRoots: [extraRoot] }, fs);
+
+    expect(installations.map((entry) => entry.executable)).toEqual([
+      studioExe(extraRoot, 'version-eee'),
+      path.join(extraRoot, STUDIO_EXECUTABLE_NAME),
+    ]);
+    expect(installations.every((entry) => entry.source === 'custom')).toBe(true);
+  });
+
+  test('missing and unreadable install roots are skipped instead of throwing', () => {
+    const fs = fakeFs({ files: {} });
+
+    expect(
+      discoverStudioInstallations({ localAppData: LOCAL_APP_DATA, roamingAppData: ROAMING_APP_DATA }, fs),
+    ).toEqual([]);
+  });
+});
+
+describe('mod loader default installation parsing', () => {
+  test('splits the source slug from the version folder', () => {
+    const fs = fakeFs({
+      files: {},
+      texts: { [path.join(RML_STUDIO, 'settings.json')]: '{"defaultInstallationId":"managed:version-268c7d94"}' },
+    });
+
+    expect(readRmlDefaultInstallation(RML_STUDIO, fs)).toEqual({
+      slug: 'managed',
+      versionFolder: 'version-268c7d94',
+    });
+  });
+
+  test('rejects malformed json, missing keys, and non-version ids', () => {
+    const cases = ['{not json', '{}', '{"defaultInstallationId":42}', '{"defaultInstallationId":"managed:../evil"}'];
+    for (const contents of cases) {
+      const fs = fakeFs({ files: {}, texts: { [path.join(RML_STUDIO, 'settings.json')]: contents } });
+      expect(readRmlDefaultInstallation(RML_STUDIO, fs)).toBeUndefined();
+    }
+  });
+});
+
+describe('studio source and search root parsing', () => {
+  test('auto and empty values mean no preference', () => {
+    expect(parseStudioInstallationSource(undefined)).toBeUndefined();
+    expect(parseStudioInstallationSource('auto')).toBeUndefined();
+    expect(parseStudioInstallationSource('  ')).toBeUndefined();
+  });
+
+  test('aliases map onto sources and unknown values fail loudly', () => {
+    expect(parseStudioInstallationSource('Official')).toBe('official');
+    expect(parseStudioInstallationSource('modloader')).toBe('rml');
+    expect(() => parseStudioInstallationSource('bloxstrap')).toThrow(/Unsupported ROBLOX_STUDIO_SOURCE/);
+  });
+
+  test('search roots split on semicolons and drop blanks', () => {
+    expect(parseStudioSearchRoots('C:\\A; ;D:\\B ')).toEqual(['C:\\A', 'D:\\B']);
+    expect(parseStudioSearchRoots(undefined)).toEqual([]);
+  });
+});

--- a/packages/core/src/__tests__/tool-schema.test.ts
+++ b/packages/core/src/__tests__/tool-schema.test.ts
@@ -364,6 +364,7 @@ describe('Tool schema compatibility', () => {
       'close',
       'status',
       'list_place_versions',
+      'list_studio_installations',
     ]);
     expect((props.source as { enum?: string[] }).enum).toEqual([
       'baseplate',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,3 +46,26 @@ export type {
   AssetVersionInfo,
   AssetVersionsResponse,
 } from './opencloud-client.js';
+export {
+  describeStudioInstallations,
+  resolveStudioExe,
+} from './studio-instance-manager.js';
+export type { StudioInstallationDiscovery } from './studio-instance-manager.js';
+export {
+  RML_LAUNCHER_DIRECTORY,
+  STUDIO_EXECUTABLE_NAME,
+  discoverStudioInstallations,
+  parseStudioInstallationSource,
+  parseStudioSearchRoots,
+  readRmlDefaultInstallation,
+  selectStudioInstallation,
+  studioInstallationRoots,
+} from './studio-installations.js';
+export type {
+  RmlDefaultInstallation,
+  StudioInstallation,
+  StudioInstallationFs,
+  StudioInstallationRoot,
+  StudioInstallationSearchPaths,
+  StudioInstallationSource,
+} from './studio-installations.js';

--- a/packages/core/src/mcp-compat.ts
+++ b/packages/core/src/mcp-compat.ts
@@ -81,6 +81,8 @@ generate_model stages generated content under ServerStorage for review. upload_a
 
 manage_instance can launch, inspect, and close Studio or list published place revisions. A process-identity launch returns a suspended launch that must be authorized and completed explicitly. Keep its launch_id until the connection has an instance_id.
 
+Launches auto-discover Studio in the official Roblox install tree and in third-party launcher trees such as Roblox Mod Loader. Use action=list_studio_installations when a launch opens the wrong build; pin one with studio_executable, ROBLOX_STUDIO_EXE, or ROBLOX_STUDIO_SOURCE.
+
 ## Roblox reference material
 
 Use get_roblox_docs for official engine and Luau reference pages. Use get_roblox_skills to list or read Roblox-authored Studio Assistant skills when their longer guidance is useful.

--- a/packages/core/src/studio-installations.ts
+++ b/packages/core/src/studio-installations.ts
@@ -1,0 +1,232 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import * as path from 'path';
+
+/**
+ * Studio installation discovery.
+ *
+ * Roblox Studio is not only installed by the official bootstrapper. Third-party
+ * launchers (notably Roblox Mod Loader) keep their own version trees and are the
+ * build a user actually runs, so auto-discovery has to look past
+ * `%LOCALAPPDATA%\Roblox\Versions`.
+ */
+
+export type StudioInstallationSource = 'official' | 'rml' | 'custom';
+
+export interface StudioInstallation {
+  /** Absolute path to RobloxStudioBeta.exe. */
+  executable: string;
+  source: StudioInstallationSource;
+  /** Versions root the executable was discovered under. */
+  root: string;
+  /** `version-<hash>` folder name, when the layout is versioned. */
+  versionFolder?: string;
+  modifiedAtMs: number;
+  /** The launcher itself declares this installation as its default. */
+  launcherDefault: boolean;
+}
+
+export interface StudioInstallationRoot {
+  path: string;
+  source: StudioInstallationSource;
+  /** Version folder the launcher declares as its default, when known. */
+  defaultVersionFolder?: string;
+  /** Root holds a single Studio directly instead of `version-*` subfolders. */
+  flat?: boolean;
+}
+
+export interface StudioInstallationFs {
+  existsSync: (target: string) => boolean;
+  readdirSync: (target: string) => string[];
+  statSync: (target: string) => { mtimeMs: number };
+  readFileSync: (target: string, encoding: 'utf8') => string;
+}
+
+export interface StudioInstallationSearchPaths {
+  /** Host-native `%LOCALAPPDATA%`. */
+  localAppData?: string;
+  /** Host-native `%APPDATA%`. */
+  roamingAppData?: string;
+  /** Extra roots, highest priority first (ROBLOX_STUDIO_SEARCH_ROOTS). */
+  extraRoots?: string[];
+}
+
+export const STUDIO_EXECUTABLE_NAME = 'RobloxStudioBeta.exe';
+
+/** Roblox Mod Loader launcher data directory, under `%APPDATA%`. */
+export const RML_LAUNCHER_DIRECTORY = 'com.revolution.rml-launcher';
+
+const VERSION_FOLDER = /^version-[a-z0-9]+$/i;
+
+const DEFAULT_FS: StudioInstallationFs = {
+  existsSync,
+  readdirSync: (target) => readdirSync(target),
+  statSync: (target) => statSync(target),
+  readFileSync: (target, encoding) => readFileSync(target, encoding),
+};
+
+export function parseStudioSearchRoots(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(';')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+export function parseStudioInstallationSource(value: string | undefined): StudioInstallationSource | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === '' || normalized === 'auto' || normalized === 'any') return undefined;
+  if (normalized === 'official' || normalized === 'roblox') return 'official';
+  if (normalized === 'rml' || normalized === 'modloader' || normalized === 'roblox-mod-loader') return 'rml';
+  if (normalized === 'custom') return 'custom';
+  throw new Error(
+    `Unsupported ROBLOX_STUDIO_SOURCE "${value}". Use auto, official, rml, or custom.`,
+  );
+}
+
+export interface RmlDefaultInstallation {
+  /** RML `InstallationSource` slug, e.g. `managed` or `roblox-official`. */
+  slug: string;
+  versionFolder: string;
+}
+
+/**
+ * `{ "defaultInstallationId": "<source>:<version-folder>" }` in the Roblox Mod
+ * Loader launcher's Studio settings names the build it opens. The slug matters:
+ * `managed` installs live in the launcher's own tree, `roblox-official` ones in
+ * the official Roblox tree.
+ */
+export function readRmlDefaultInstallation(
+  studioDirectory: string,
+  fileSystem: StudioInstallationFs = DEFAULT_FS,
+): RmlDefaultInstallation | undefined {
+  const settingsPath = path.join(studioDirectory, 'settings.json');
+  if (!fileSystem.existsSync(settingsPath)) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fileSystem.readFileSync(settingsPath, 'utf8'));
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object' || !('defaultInstallationId' in parsed)) return undefined;
+  const id = parsed.defaultInstallationId;
+  if (typeof id !== 'string') return undefined;
+  const separator = id.lastIndexOf(':');
+  const slug = separator === -1 ? 'managed' : id.slice(0, separator);
+  const versionFolder = separator === -1 ? id : id.slice(separator + 1);
+  if (!VERSION_FOLDER.test(versionFolder)) return undefined;
+  return { slug, versionFolder };
+}
+
+export function studioInstallationRoots(
+  paths: StudioInstallationSearchPaths,
+  fileSystem: StudioInstallationFs = DEFAULT_FS,
+): StudioInstallationRoot[] {
+  const roots: StudioInstallationRoot[] = [];
+  const rmlStudioDirectory = paths.roamingAppData
+    ? path.join(paths.roamingAppData, RML_LAUNCHER_DIRECTORY, 'studio')
+    : undefined;
+  const rmlDefault = rmlStudioDirectory
+    ? readRmlDefaultInstallation(rmlStudioDirectory, fileSystem)
+    : undefined;
+
+  for (const extra of paths.extraRoots ?? []) {
+    roots.push({ path: extra, source: 'custom' });
+    roots.push({ path: extra, source: 'custom', flat: true });
+  }
+
+  if (paths.localAppData) {
+    roots.push({
+      path: path.join(paths.localAppData, 'Roblox', 'Versions'),
+      source: 'official',
+      defaultVersionFolder: rmlDefault?.slug === 'roblox-official' ? rmlDefault.versionFolder : undefined,
+    });
+  }
+
+  if (rmlStudioDirectory) {
+    roots.push({
+      path: path.join(rmlStudioDirectory, 'versions'),
+      source: 'rml',
+      defaultVersionFolder: rmlDefault?.slug === 'managed' ? rmlDefault.versionFolder : undefined,
+    });
+  }
+
+  return roots;
+}
+
+export function discoverStudioInstallations(
+  paths: StudioInstallationSearchPaths,
+  fileSystem: StudioInstallationFs = DEFAULT_FS,
+): StudioInstallation[] {
+  const found: StudioInstallation[] = [];
+  const seen = new Set<string>();
+
+  for (const root of studioInstallationRoots(paths, fileSystem)) {
+    if (!fileSystem.existsSync(root.path)) continue;
+
+    let entries: string[] = [''];
+    if (!root.flat) {
+      try {
+        entries = fileSystem.readdirSync(root.path).filter((name) => VERSION_FOLDER.test(name));
+      } catch {
+        continue;
+      }
+    }
+
+    for (const entry of entries) {
+      const directory = entry ? path.join(root.path, entry) : root.path;
+      const executable = path.join(directory, STUDIO_EXECUTABLE_NAME);
+      if (!fileSystem.existsSync(executable)) continue;
+      if (seen.has(executable)) continue;
+      seen.add(executable);
+
+      let modifiedAtMs = 0;
+      try {
+        modifiedAtMs = fileSystem.statSync(executable).mtimeMs;
+      } catch {
+        continue;
+      }
+
+      found.push({
+        executable,
+        source: root.source,
+        root: root.path,
+        versionFolder: entry || undefined,
+        modifiedAtMs,
+        launcherDefault: Boolean(entry) && entry === root.defaultVersionFolder,
+      });
+    }
+  }
+
+  return found.sort(compareStudioInstallations);
+}
+
+/**
+ * A launcher-declared default outranks the newest build: the launcher knows
+ * which Studio the user actually opens, mtime is only a guess. Ties fall back
+ * to newest first so the previous behaviour is preserved when nothing declares
+ * a default.
+ */
+export function compareStudioInstallations(a: StudioInstallation, b: StudioInstallation): number {
+  if (a.launcherDefault !== b.launcherDefault) return a.launcherDefault ? -1 : 1;
+  if (b.modifiedAtMs !== a.modifiedAtMs) return b.modifiedAtMs - a.modifiedAtMs;
+  return a.executable.localeCompare(b.executable);
+}
+
+export function selectStudioInstallation(
+  installations: StudioInstallation[],
+  preferredSource?: StudioInstallationSource,
+): StudioInstallation | undefined {
+  const candidates = preferredSource
+    ? installations.filter((installation) => installation.source === preferredSource)
+    : installations;
+  return [...candidates].sort(compareStudioInstallations)[0];
+}
+
+export function describeStudioInstallationRoots(roots: StudioInstallationRoot[]): string {
+  const unique = new Map<string, StudioInstallationSource>();
+  for (const root of roots) {
+    if (!unique.has(root.path)) unique.set(root.path, root.source);
+  }
+  return [...unique.entries()].map(([root, source]) => `${root} (${source})`).join(', ');
+}

--- a/packages/core/src/studio-instance-manager.ts
+++ b/packages/core/src/studio-instance-manager.ts
@@ -17,6 +17,19 @@ import {
   type StudioPlatformCapabilities,
   type StudioProcessIdentityLauncher,
 } from './studio-platform.js';
+import {
+  STUDIO_EXECUTABLE_NAME,
+  describeStudioInstallationRoots,
+  discoverStudioInstallations,
+  parseStudioInstallationSource,
+  parseStudioSearchRoots,
+  selectStudioInstallation,
+  studioInstallationRoots,
+  type StudioInstallation,
+  type StudioInstallationRoot,
+  type StudioInstallationSearchPaths,
+  type StudioInstallationSource,
+} from './studio-installations.js';
 
 export type StudioLaunchSource = 'baseplate' | 'local_file' | 'published_place' | 'place_revision';
 
@@ -241,11 +254,11 @@ async function powershellAsync(script: string): Promise<string> {
   });
 }
 
-function windowsLocalAppData(): string | undefined {
-  if (process.platform === 'win32') return process.env.LOCALAPPDATA;
+function windowsEnvironmentDirectory(variable: 'LOCALAPPDATA' | 'APPDATA'): string | undefined {
+  if (process.platform === 'win32') return process.env[variable];
   if (!isWsl()) return undefined;
   try {
-    return run('cmd.exe', ['/c', 'echo %LOCALAPPDATA%'], {
+    return run('cmd.exe', ['/c', `echo %${variable}%`], {
       cwd: existsSync('/mnt/c/Windows') ? '/mnt/c/Windows' : process.cwd(),
     });
   } catch {
@@ -253,11 +266,13 @@ function windowsLocalAppData(): string | undefined {
   }
 }
 
-async function windowsLocalAppDataAsync(): Promise<string | undefined> {
-  if (process.platform === 'win32') return process.env.LOCALAPPDATA;
+async function windowsEnvironmentDirectoryAsync(
+  variable: 'LOCALAPPDATA' | 'APPDATA',
+): Promise<string | undefined> {
+  if (process.platform === 'win32') return process.env[variable];
   if (!isWsl()) return undefined;
   try {
-    return await runAsync('cmd.exe', ['/c', 'echo %LOCALAPPDATA%'], {
+    return await runAsync('cmd.exe', ['/c', `echo %${variable}%`], {
       cwd: existsSync('/mnt/c/Windows') ? '/mnt/c/Windows' : process.cwd(),
     });
   } catch {
@@ -1123,64 +1138,130 @@ function prepareStudioLaunchOptions(options: StudioLaunchOptions): StudioLaunchO
   };
 }
 
+const MACOS_STUDIO_EXECUTABLE = '/Applications/RobloxStudio.app/Contents/MacOS/RobloxStudio';
+
+export interface StudioInstallationDiscovery {
+  /** Every Studio found, best candidate first. */
+  installations: StudioInstallation[];
+  /** Roots that were searched, whether or not they exist. */
+  roots: StudioInstallationRoot[];
+  /** ROBLOX_STUDIO_SOURCE filter in effect, if any. */
+  preferredSource?: StudioInstallationSource;
+  /** Installation auto-discovery would launch. */
+  selected?: StudioInstallation;
+  /** ROBLOX_STUDIO_EXE, which wins over discovery. */
+  executableOverride?: string;
+}
+
+function assertStudioDiscoverySupported(): void {
+  if (process.platform !== 'win32' && !isWsl()) {
+    throw new Error('Roblox Studio executable auto-discovery is only supported on Windows, WSL, and macOS. Set ROBLOX_STUDIO_EXE.');
+  }
+}
+
+function studioSearchPathsFrom(
+  localAppData: string | undefined,
+  roamingAppData: string | undefined,
+  toHostPath: (windowsPath: string) => string,
+): StudioInstallationSearchPaths {
+  return {
+    localAppData: localAppData ? toHostPath(localAppData) : path.join(os.homedir(), 'AppData', 'Local'),
+    roamingAppData: roamingAppData ? toHostPath(roamingAppData) : path.join(os.homedir(), 'AppData', 'Roaming'),
+    extraRoots: parseStudioSearchRoots(process.env.ROBLOX_STUDIO_SEARCH_ROOTS),
+  };
+}
+
+function describeStudioInstallationsFor(searchPaths: StudioInstallationSearchPaths): StudioInstallationDiscovery {
+  const preferredSource = parseStudioInstallationSource(process.env.ROBLOX_STUDIO_SOURCE);
+  const installations = discoverStudioInstallations(searchPaths);
+  return {
+    installations,
+    roots: studioInstallationRoots(searchPaths),
+    preferredSource,
+    selected: selectStudioInstallation(installations, preferredSource),
+    executableOverride: process.env.ROBLOX_STUDIO_EXE || undefined,
+  };
+}
+
+/**
+ * Studio installs the server can see, for diagnosing which build a launch
+ * would use. Official Roblox and third-party launcher trees are both reported.
+ */
+export function describeStudioInstallations(): StudioInstallationDiscovery {
+  if (process.platform === 'darwin') {
+    return {
+      installations: [],
+      roots: [],
+      selected: existsSync(MACOS_STUDIO_EXECUTABLE)
+        ? {
+          executable: MACOS_STUDIO_EXECUTABLE,
+          source: 'official',
+          root: path.dirname(MACOS_STUDIO_EXECUTABLE),
+          modifiedAtMs: statSync(MACOS_STUDIO_EXECUTABLE).mtimeMs,
+          launcherDefault: false,
+        }
+        : undefined,
+      executableOverride: process.env.ROBLOX_STUDIO_EXE || undefined,
+    };
+  }
+
+  assertStudioDiscoverySupported();
+  return describeStudioInstallationsFor(
+    studioSearchPathsFrom(
+      windowsEnvironmentDirectory('LOCALAPPDATA'),
+      windowsEnvironmentDirectory('APPDATA'),
+      toWslPath,
+    ),
+  );
+}
+
+function studioDiscoveryFailure(discovery: StudioInstallationDiscovery): Error {
+  const searched = describeStudioInstallationRoots(discovery.roots);
+  if (discovery.preferredSource && discovery.installations.length > 0) {
+    return new Error(
+      `No ${STUDIO_EXECUTABLE_NAME} found for ROBLOX_STUDIO_SOURCE=${discovery.preferredSource}. ` +
+      `Discovered sources: ${[...new Set(discovery.installations.map((i) => i.source))].join(', ')}. ` +
+      'Set ROBLOX_STUDIO_EXE or change ROBLOX_STUDIO_SOURCE.',
+    );
+  }
+  return new Error(
+    `${STUDIO_EXECUTABLE_NAME} not found. Searched: ${searched || '(no known install roots)'}. ` +
+    'Set ROBLOX_STUDIO_EXE, or add the launcher directory to ROBLOX_STUDIO_SEARCH_ROOTS.',
+  );
+}
+
 export function resolveStudioExe(): string {
   if (process.env.ROBLOX_STUDIO_EXE) return process.env.ROBLOX_STUDIO_EXE;
 
   if (process.platform === 'darwin') {
-    return '/Applications/RobloxStudio.app/Contents/MacOS/RobloxStudio';
+    return MACOS_STUDIO_EXECUTABLE;
   }
 
-  if (process.platform !== 'win32' && !isWsl()) {
-    throw new Error('Roblox Studio executable auto-discovery is only supported on Windows, WSL, and macOS. Set ROBLOX_STUDIO_EXE.');
-  }
-
-  const localAppData = windowsLocalAppData();
-  const root = localAppData
-    ? path.join(toWslPath(localAppData), 'Roblox', 'Versions')
-    : path.join(os.homedir(), 'AppData', 'Local', 'Roblox', 'Versions');
-
-  if (!existsSync(root)) {
-    throw new Error(`Roblox Studio Versions folder not found: ${root}. Set ROBLOX_STUDIO_EXE.`);
-  }
-
-  const candidates = readdirSync(root)
-    .filter((name) => name.startsWith('version-'))
-    .map((name) => path.join(root, name, 'RobloxStudioBeta.exe'))
-    .filter((candidate) => existsSync(candidate))
-    .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
-
-  if (candidates.length === 0) {
-    throw new Error(`RobloxStudioBeta.exe not found under ${root}. Set ROBLOX_STUDIO_EXE.`);
-  }
-
-  return candidates[0];
+  const discovery = describeStudioInstallations();
+  if (!discovery.selected) throw studioDiscoveryFailure(discovery);
+  return discovery.selected.executable;
 }
 
 async function resolveStudioExeAsync(): Promise<string> {
   if (process.env.ROBLOX_STUDIO_EXE) return process.env.ROBLOX_STUDIO_EXE;
   if (process.platform === 'darwin') {
-    return '/Applications/RobloxStudio.app/Contents/MacOS/RobloxStudio';
+    return MACOS_STUDIO_EXECUTABLE;
   }
-  if (process.platform !== 'win32' && !isWsl()) {
-    throw new Error('Roblox Studio executable auto-discovery is only supported on Windows, WSL, and macOS. Set ROBLOX_STUDIO_EXE.');
-  }
+  assertStudioDiscoverySupported();
 
-  const localAppData = await windowsLocalAppDataAsync();
-  const root = localAppData
-    ? path.join(await toWslPathAsync(localAppData), 'Roblox', 'Versions')
-    : path.join(os.homedir(), 'AppData', 'Local', 'Roblox', 'Versions');
-  if (!existsSync(root)) {
-    throw new Error(`Roblox Studio Versions folder not found: ${root}. Set ROBLOX_STUDIO_EXE.`);
-  }
-  const candidates = readdirSync(root)
-    .filter((name) => name.startsWith('version-'))
-    .map((name) => path.join(root, name, 'RobloxStudioBeta.exe'))
-    .filter((candidate) => existsSync(candidate))
-    .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
-  if (candidates.length === 0) {
-    throw new Error(`RobloxStudioBeta.exe not found under ${root}. Set ROBLOX_STUDIO_EXE.`);
-  }
-  return candidates[0];
+  const [localAppData, roamingAppData] = await Promise.all([
+    windowsEnvironmentDirectoryAsync('LOCALAPPDATA'),
+    windowsEnvironmentDirectoryAsync('APPDATA'),
+  ]);
+  const searchPaths = studioSearchPathsFrom(
+    localAppData ? await toWslPathAsync(localAppData) : undefined,
+    roamingAppData ? await toWslPathAsync(roamingAppData) : undefined,
+    (hostPath) => hostPath,
+  );
+
+  const discovery = describeStudioInstallationsFor(searchPaths);
+  if (!discovery.selected) throw studioDiscoveryFailure(discovery);
+  return discovery.selected.executable;
 }
 
 export function listStudioProcesses(): StudioProcessInfo[] {

--- a/packages/core/src/tools/definitions.ts
+++ b/packages/core/src/tools/definitions.ts
@@ -468,13 +468,13 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'manage_instance',
     category: 'write',
-    description: 'Use to manage Studio processes or list place revisions.',
+    description: 'Use to manage Studio processes, list place revisions, or list Studio installs.',
     inputSchema: {
       type: 'object',
       properties: {
         action: {
           type: 'string',
-          enum: ['launch', 'authorize', 'complete', 'close', 'status', 'list_place_versions'],
+          enum: ['launch', 'authorize', 'complete', 'close', 'status', 'list_place_versions', 'list_studio_installations'],
           description: 'Operation; authorize and complete only resume identity launches.'
         },
         source: {

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -8,6 +8,7 @@ import {
 } from '../opencloud-client.js';
 import { RobloxCookieClient } from '../roblox-cookie-client.js';
 import {
+  describeStudioInstallations,
   parseStudioProcessEnvironmentPatch,
   parseStudioWorkingDirectory,
   StudioInstanceManager,
@@ -3028,9 +3029,33 @@ export class RobloxStudioTools {
       action !== 'complete' &&
       action !== 'close' &&
       action !== 'status' &&
-      action !== 'list_place_versions'
+      action !== 'list_place_versions' &&
+      action !== 'list_studio_installations'
     ) {
-      throw new Error('manage_instance requires action=launch|authorize|complete|close|status|list_place_versions');
+      throw new Error('manage_instance requires action=launch|authorize|complete|close|status|list_place_versions|list_studio_installations');
+    }
+
+    if (action === 'list_studio_installations') {
+      const discovery = describeStudioInstallations();
+      return this._textResult({
+        selected_executable: discovery.executableOverride ?? discovery.selected?.executable,
+        selection_reason: discovery.executableOverride
+          ? 'ROBLOX_STUDIO_EXE'
+          : discovery.selected?.launcherDefault
+            ? 'launcher default'
+            : discovery.selected
+              ? 'most recently modified'
+              : 'none found',
+        preferred_source: discovery.preferredSource,
+        searched_roots: [...new Set(discovery.roots.map((root) => root.path))],
+        installations: discovery.installations.map((installation) => ({
+          executable: installation.executable,
+          source: installation.source,
+          version_folder: installation.versionFolder,
+          launcher_default: installation.launcherDefault,
+          modified_at: new Date(installation.modifiedAtMs).toISOString(),
+        })),
+      });
     }
 
     if (action === 'list_place_versions') {


### PR DESCRIPTION
## Summary

- search the Roblox ModLoader launcher's Studio tree (`%APPDATA%\com.revolution.rml-launcher\studio\versions`) alongside `%LOCALAPPDATA%\Roblox\Versions`
- honor the instance that launcher records as its default in `studio/settings.json`, resolving `managed:` ids to its own tree and `roblox-official:` ids to the official one
- add `ROBLOX_STUDIO_SEARCH_ROOTS` for any other launcher and `ROBLOX_STUDIO_SOURCE` to pin discovery to one install source
- add `manage_instance action=list_studio_installations`, which reports every install found, the one a launch would use, and why

## Why

`resolveStudioExe()` only enumerated `%LOCALAPPDATA%\Roblox\Versions` and picked the newest `RobloxStudioBeta.exe` by mtime. That assumption holds for the official bootstrapper, and it is worth explaining why it breaks, because this is not a one-user problem.

[Roblox ModLoader](https://github.com/revolutionxk/roblox-modloader) is an MIT-licensed modding framework for Studio (native C++/C# mods, internal Luau scripting). Its README documents a manual install into `%LOCALAPPDATA%\Roblox\Versions\<version>\`, and that path stays compatible with this server. But its companion [rml-launcher](https://github.com/revolutionxk/rml-launcher) is built around *instances*: "every installed Roblox Studio build is its own instance with its own mod loader, mods and engine flags". Those instances are downloaded into the launcher's own Tauri app-data directory, not into the Roblox tree:

```
%APPDATA%\com.revolution.rml-launcher\studio\
├── settings.json           {"defaultInstallationId":"managed:version-<hash>"}
└── versions\
    └── version-<hash>\
        ├── RobloxStudioBeta.exe
        └── RobloxModLoader\
```

So for anyone who installs Studio through that launcher, which is the path its README recommends and the one that keeps the loader updated, `%LOCALAPPDATA%\Roblox\Versions` holds either nothing or an unrelated official build. The failure is silent in the worst way: on my machine the official tree still had a stale `version-7dcd5b9208284dcb` (2026-08-07), while all five Studio windows I work in are `version-268c7d941ba34c1a` (2026-08-31) from the launcher. Every `manage_instance action=launch` opened the stale build, and the plugin then connected to a Studio that had none of my places. On a machine with no official Studio at all, the launch fails outright with `Roblox Studio Versions folder not found`.

Discovery now walks every known install root, and treats a launcher-declared default as stronger evidence than a modification timestamp, because the launcher knows which build it opens. The launcher's `defaultInstallationId` is `"<source>:<version-folder>"`, and the source slug decides the tree (`managed`, `roblox-official`, `bloxstrap`, `mac-bundle`, `vinegar` in its `InstallationSource` enum), so a default is only honored when the build is actually found under the matching root. Errors now list the roots that were searched instead of naming a single hardcoded folder.

`ROBLOX_STUDIO_SEARCH_ROOTS` exists so this does not need a new code path per launcher: any root is accepted, with both `version-*/RobloxStudioBeta.exe` and a bare `RobloxStudioBeta.exe` inside it.

## Compatibility

- machines with only the official install resolve exactly as before: newest `RobloxStudioBeta.exe` by mtime
- `ROBLOX_STUDIO_SOURCE=official` restores official-only discovery for anyone who has both trees and wants the old choice
- `studio_executable` on the launch request and `ROBLOX_STUDIO_EXE` still take precedence over discovery
- a manual ModLoader install, extracted into the official Studio folder per its README, was already supported and is unaffected
- macOS resolution and the WSL `cmd.exe` / `wslpath` path are unchanged; `windowsLocalAppData()` becomes `windowsEnvironmentDirectory('LOCALAPPDATA' | 'APPDATA')` with the same semantics
- no tool, action, or launch parameter was removed; `manage_instance` only gains one action
- discovery skips missing or unreadable roots instead of throwing, so a half-installed launcher cannot break a launch

## Known limits

- only the Windows launcher layout is detected natively. The launcher's macOS instances use `RobloxStudio.app/Contents/MacOS/RobloxStudio` inside the version folder, and its Linux support runs Studio through Vinegar. Neither is discovered, and both would need their own probe.
- Bloxstrap and other launchers are reachable only through `ROBLOX_STUDIO_SEARCH_ROOTS`.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test -w packages/core`: 27 suites, 369 tests, including 12 new cases in `packages/core/src/__tests__/studio-installations.test.ts`
- `npx eslint` on the changed files, clean. `npm run lint` still reports the 7 pre-existing errors in `install-plugin-helpers.ts`, `opencloud-client.ts`, and the two `install-plugin.ts` files, none of them touched here.
- `npm pack --dry-run -w packages/robloxstudio-mcp` after `npm run build:plugins`
- live launch: `manage_instance action=launch source=local_file` spawned pid 62636 with `Path = ...rml-launcher\studio\versions\version-268c7d941ba34c1a\RobloxStudioBeta.exe`; `action=close` returned `{"status":"closed"}`
- live discovery: `POST /mcp/manage_instance {"action":"list_studio_installations"}` returned `selection_reason: "launcher default"` and 6 installs across both trees

Discovery is unit-tested against an injected filesystem, so both launcher layouts are covered without either launcher being installed on CI.
