### PR TITLE
fix: block write endpoints through the Inspector proxy

### DIFF
--- a/packages/core/src/__tests__/http-security.test.ts
+++ b/packages/core/src/__tests__/http-security.test.ts
@@ -7,6 +7,7 @@ import type { Server } from 'node:http';
 import WebSocket from 'ws';
 import type { RawData } from 'ws';
 import type { StudioServerEvent } from '../studio-transport.js';
+import { getAllTools, getReadOnlyTools } from '../tools/definitions.js';
 
 class HttpTestBridgeService extends BridgeService {
   protected override notifyPeerRegistered(): void {
@@ -25,6 +26,78 @@ describe('HTTP security', () => {
 
   afterEach(() => {
     bridge.clearAllPendingRequests();
+  });
+
+  describe('proxy tool permissions', () => {
+    const token = 'proxy-test-token';
+
+    it.each([
+      { label: 'unrestricted', allowed: undefined, endpoint: '/api/execute-luau', status: 200 },
+      { label: 'main', allowed: new Set(getAllTools().map(tool => tool.name)),
+        endpoint: '/api/execute-luau', status: 200 },
+      { label: 'empty', allowed: new Set<string>(), endpoint: '/api/place-info', status: 403 },
+      { label: 'narrow', allowed: new Set(['get_script_source']), endpoint: '/api/place-info', status: 403 },
+      { label: 'narrow read', allowed: new Set(['get_script_source']),
+        endpoint: '/api/get-script-source', status: 200 },
+      { label: 'simulation read', allowed: new Set(['get_simulation_state', 'get_device_simulator_state']),
+        endpoint: '/api/execute-luau', status: 403 },
+    ])('enforces $label configuration', async ({ allowed, endpoint, status }) => {
+      const app = createHttpServer(tools, bridge, allowed, undefined, { authToken: token });
+      const dispatch = jest.spyOn(bridge, 'sendRequest').mockResolvedValue({ success: true });
+      try {
+        await request(app).post('/proxy').set('X-MCP-Auth', token)
+          .send({ endpoint, targetPeerId: 'studio-peer' }).expect(status);
+        expect(dispatch).toHaveBeenCalledTimes(status === 200 ? 1 : 0);
+      } finally {
+        dispatch.mockRestore();
+        await app.cleanup();
+      }
+    });
+
+    it.each([
+      '/api/execute-luau',
+      '/api/eval-runtime',
+      '/api/set-properties',
+      '/api/set-script-source',
+      '/api/import-rbxm',
+      '/api/unknown-operation',
+    ])('rejects Inspector endpoint %s before dispatch', async (endpoint) => {
+      const app = createHttpServer(tools, bridge, new Set(getReadOnlyTools().map(tool => tool.name)),
+        undefined, { authToken: token });
+      const dispatch = jest.spyOn(bridge, 'sendRequest').mockResolvedValue({ success: true });
+      try {
+        const response = await request(app).post('/proxy').set('X-MCP-Auth', token)
+          .send({ endpoint, data: { code: 'return true' }, targetPeerId: 'studio-peer' });
+        expect(response.status).toBe(403);
+        expect(response.body.error).toBe('forbidden_endpoint');
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        dispatch.mockRestore();
+        await app.cleanup();
+      }
+    });
+
+    it.each(['/api/place-info', '/api/instance-properties', '/api/get-script-source',
+      '/api/get-selection', '/api/set-selection', '/api/focus-viewport',
+      '/api/capture-begin', '/api/capture-read', '/api/get-runtime-logs'])(
+      'forwards permitted Inspector endpoint %s', async (endpoint) => {
+        const app = createHttpServer(tools, bridge, new Set(getReadOnlyTools().map(tool => tool.name)),
+          undefined, { authToken: token });
+        const result = { value: 'read-result' };
+        const dispatch = jest.spyOn(bridge, 'sendRequest').mockResolvedValue(result);
+        try {
+          const response = await request(app).post('/proxy').set('Authorization', `Bearer ${token}`)
+            .send({ endpoint, data: { instancePath: 'game.Workspace' }, targetPeerId: 'studio-peer',
+              timeoutMs: 1000, operationId: 'read-operation' });
+          expect(response.status).toBe(200);
+          expect(response.body).toEqual({ response: result });
+          expect(dispatch).toHaveBeenCalledWith(endpoint, { instancePath: 'game.Workspace' },
+            'studio-peer', 1000, expect.any(AbortSignal), 'read-operation');
+        } finally {
+          dispatch.mockRestore();
+          await app.cleanup();
+        }
+      });
   });
 
   describe('origin policy', () => {

--- a/packages/core/src/http-server.ts
+++ b/packages/core/src/http-server.ts
@@ -47,6 +47,47 @@ interface StreamableHttpConfig {
   tools: ToolDefinition[];
 }
 
+// Explicit wire endpoints: public tool names do not always match Studio handlers.
+// Never grant execute-luau through a read tool that happens to use generated Luau.
+const TOOL_PROXY_ENDPOINTS: Record<string, readonly string[]> = {
+  get_place_info: ['/api/place-info'],
+  search_objects: ['/api/search-objects'],
+  get_instance_properties: ['/api/instance-properties'],
+  get_project_structure: ['/api/project-structure'],
+  set_properties: ['/api/set-properties'],
+  get_script_source: ['/api/get-script-source'],
+  set_script_source: ['/api/set-script-source'],
+  edit_script_lines: ['/api/edit-script-lines'],
+  insert_script_lines: ['/api/insert-script-lines'],
+  delete_script_lines: ['/api/delete-script-lines'],
+  get_attributes: ['/api/get-attributes'],
+  selection: ['/api/get-selection', '/api/set-selection', '/api/focus-viewport'],
+  execute_luau: ['/api/execute-luau'],
+  eval_server_runtime: ['/api/eval-runtime'],
+  eval_client_runtime: ['/api/eval-runtime'],
+  grep_scripts: ['/api/grep-scripts'],
+  solo_playtest: ['/api/start-playtest', '/api/stop-playtest', '/api/multiplayer-test-state'],
+  multiplayer_playtest: [
+    '/api/multiplayer-test-start', '/api/multiplayer-test-add-players',
+    '/api/multiplayer-test-leave-client', '/api/multiplayer-test-end', '/api/multiplayer-test-state',
+  ],
+  get_runtime_logs: ['/api/get-runtime-logs'],
+  capture_script_profiler: ['/api/capture-script-profiler'],
+  capture_micro_profiler: ['/api/capture-micro-profiler'],
+  breakpoints: ['/api/breakpoints'],
+  insert_asset: ['/api/insert-asset'],
+  generate_model: ['/api/generate-model'],
+  preview_asset: ['/api/preview-asset'],
+  capture_screenshot: ['/api/capture-screenshot', '/api/capture-begin', '/api/capture-read'],
+  simulate_mouse_input: ['/api/simulate-mouse-input'],
+  simulate_keyboard_input: ['/api/simulate-keyboard-input'],
+  get_memory_breakdown: ['/api/get-memory-breakdown'],
+  get_scene_analysis: ['/api/get-scene-analysis'],
+  export_rbxm: ['/api/export-rbxm'],
+  import_rbxm: ['/api/import-rbxm'],
+  find_and_replace_in_scripts: ['/api/find-and-replace-in-scripts'],
+};
+
 type PassiveStudioPeer = Omit<PublicStudioPeer, 'peerId'>;
 type PassiveStudioInstance = Omit<PublicStudioInstance, 'peers'> & {
   peers: PassiveStudioPeer[];
@@ -263,6 +304,11 @@ function rejectStudioUpgrade(socket: Duplex, status: number, error: string): voi
 export function createHttpServer(tools: RobloxStudioTools, bridge: BridgeService, allowedTools?: Set<string>, serverConfig?: StreamableHttpConfig, security?: HttpSecurityOptions): RobloxStudioHttpApp {
   // Express cannot know about the lifecycle controls attached below.
   const app = express() as unknown as RobloxStudioHttpApp;
+  const allowedProxyEndpoints = allowedTools
+    ? new Set(Object.entries(TOOL_PROXY_ENDPOINTS)
+      .filter(([toolName]) => allowedTools.has(toolName))
+      .flatMap(([, endpoints]) => endpoints))
+    : undefined;
   const studioLifecycleCallable = !allowedTools || allowedTools.has('manage_instance');
   const studioLifecycleCapabilities = studioLifecycleCallable
     ? tools.getStudioLifecycleCapabilities()
@@ -824,6 +870,11 @@ export function createHttpServer(tools: RobloxStudioTools, bridge: BridgeService
 
     if (!endpoint || !targetPeerId) {
       res.status(400).json({ error: 'endpoint and targetPeerId are required' });
+      return;
+    }
+
+    if (allowedProxyEndpoints && !allowedProxyEndpoints.has(endpoint)) {
+      res.status(403).json({ error: 'forbidden_endpoint' });
       return;
     }
 


### PR DESCRIPTION
## Summary
- Enforce configured tool permissions at authenticated proxy dispatch using explicit Studio endpoint mappings.
- Reject disallowed and unknown endpoints before Studio dispatch; retain permitted reads, selection/camera, and screenshot aliases.
- Fail closed for simulation reads that internally depend on arbitrary Luau execution.
- Add regression coverage for Inspector, full-access, empty, and restricted tool configurations.

## Validation
- Core suite: 584 tests passed across 35 suites.
- TypeScript typecheck and git diff --check passed.
- Fresh server build passed.
- Feature gate npm run test:e2e: 3/3 live Studio suites passed (tooling, execution contexts, MicroProfiler responsiveness).
- Reinstalled local plugin dependencies to resolve an initial rbxtsc permission error; no dependency files changed.

Fixes #77.