### PR TITLE
fix: propagate Studio handler failures into MCP isError

### DIFF
--- a/packages/core/src/__tests__/mcp-runtime.test.ts
+++ b/packages/core/src/__tests__/mcp-runtime.test.ts
@@ -76,6 +76,56 @@ describe('MCP v2 tool runtime', () => {
     ]);
   });
 
+  describe.each(['modern', 'legacy'] as const)('%s handler failure projection', (era) => {
+    test.each([
+      { error: 'Instance not found' },
+      { success: false, message: 'Operation refused' },
+      {
+        success: false,
+        instancePath: 'game.Workspace.Part',
+        summary: { total: 2, succeeded: 1, failed: 1 },
+        results: [
+          { property: 'Name', success: true },
+          { property: 'Missing', success: false, error: 'Invalid property' },
+        ],
+      },
+    ])('flags explicit failure and preserves details: %j', (payload) => {
+      for (const raw of [
+        { content: [{ type: 'text', text: JSON.stringify(payload) }] },
+        { content: [], structuredContent: payload },
+      ]) {
+        const result = normalizeToolResult(raw, era);
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toEqual(payload);
+        expect(result.content).toEqual(era === 'modern'
+          ? []
+          : [{ type: 'text', text: JSON.stringify(payload) }]);
+      }
+    });
+
+    test.each([
+      { success: true },
+      { error: '' },
+      { error: null },
+      { error: false },
+      { returnValue: { success: false, error: 'User data' } },
+      { output: ['error: example'], message: 'No error occurred' },
+    ])('does not infer failure from ordinary data: %j', (payload) => {
+      expect(normalizeToolResult({
+        content: [{ type: 'text', text: JSON.stringify(payload) }],
+      }, era).isError).not.toBe(true);
+    });
+
+    test('preserves explicit MCP errors with text or structured content', () => {
+      for (const text of ['plain error', JSON.stringify({ success: true })]) {
+        expect(normalizeToolResult({
+          isError: true,
+          content: [{ type: 'text', text }],
+        }, era).isError).toBe(true);
+      }
+    });
+  });
+
   test('preserves public empty collections and null values', () => {
     const result = normalizeToolResult({
       content: [{

--- a/packages/core/src/__tests__/studio-handler-failures.test.ts
+++ b/packages/core/src/__tests__/studio-handler-failures.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { runInNewContext } from 'node:vm';
+import ts from 'typescript';
+import { Client, InMemoryTransport } from '@modelcontextprotocol/client';
+import { BridgeService } from '../bridge-service.js';
+import { createToolServer } from '../mcp-runtime.js';
+import { TOOL_HANDLERS } from '../http-server.js';
+import { RobloxStudioTools } from '../tools/index.js';
+import { TOOL_DEFINITIONS } from '../tools/definitions.js';
+
+// Execute the actual handler with only Roblox services/globals replaced. This
+// verifies its aggregate status without requiring a running Studio instance.
+function propertyHandlerResult(properties: Record<string, unknown>) {
+  const instance = {
+    Name: 'Part',
+    IsA: () => false,
+    set Invalid(_value: unknown) { throw new Error('Invalid property'); },
+  };
+  const finishRecording = jest.fn();
+  const source = readFileSync(resolve(__dirname, '../../../../studio-plugin/src/modules/handlers/PropertyHandlers.ts'), 'utf8');
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+  });
+  const module = { exports: {} };
+  runInNewContext(compiled.outputText, {
+    module,
+    exports: module.exports,
+    require: (name: string) => {
+      if (name === '../Utils') return { default: {
+        getInstanceByPath: () => instance,
+        convertPropertyValue: (_instance: unknown, _property: string, value: unknown) => value,
+      } };
+      if (name === '../Recording') return { default: {
+        beginRecording: () => 'recording', finishRecording,
+      } };
+      throw new Error(`Unexpected dependency: ${name}`);
+    },
+    pairs: Object.entries,
+    typeIs: (value: unknown, kind: string) => kind === 'table' ? typeof value === 'object' : typeof value === kind,
+    tostring: String,
+    pcall: (callback: () => void) => {
+      try { callback(); return [true]; } catch (error) { return [false, String(error)]; }
+    },
+  });
+  const handler = module.exports;
+  if (!('setProperties' in handler) || typeof handler.setProperties !== 'function') {
+    throw new Error('Property handler did not export setProperties');
+  }
+  const result: unknown = handler.setProperties({ instancePath: 'game.Workspace.Part', properties });
+  expect(finishRecording).toHaveBeenCalledWith('recording', true);
+  return result;
+}
+
+describe.each(['modern', 'legacy'] as const)('Studio handler failures over %s MCP', (era) => {
+  test.each([
+    { properties: { Name: 'Renamed' }, failed: 0, succeeded: 1 },
+    { properties: { Invalid: true }, failed: 1, succeeded: 0 },
+    { properties: { Name: 'Renamed', Invalid: true }, failed: 1, succeeded: 1 },
+  ])('preserves property write outcomes: %j', async ({ properties, failed, succeeded }) => {
+    const payload = propertyHandlerResult(properties);
+    expect(payload).toMatchObject({
+      success: failed === 0,
+      summary: { total: failed + succeeded, failed, succeeded },
+    });
+    const bridge = new BridgeService();
+    bridge.registerPeer({ peerId: 'edit', transportPeerId: 'edit', instanceId: 'instance:test', role: 'edit' });
+    const sendRequest = jest.spyOn(bridge, 'sendRequest').mockResolvedValue(payload);
+    const tools = new RobloxStudioTools(bridge);
+    const definition = TOOL_DEFINITIONS.find(tool => tool.name === 'set_properties')!;
+    const server = createToolServer({
+      config: { name: 'handler-test', version: '1.0.0', tools: [definition] },
+      getTools: () => tools,
+      era,
+      invoke: (target, name, args, context) => TOOL_HANDLERS[name](target, args, context),
+    });
+    const client = new Client({ name: 'handler-test-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+      const result = await client.callTool({
+        name: 'set_properties', arguments: { instancePath: 'game.Workspace.Part', properties },
+      });
+      expect(sendRequest).toHaveBeenCalled();
+      expect(result.isError === true).toBe(failed > 0);
+      expect(result.structuredContent).toEqual(payload);
+      if (era === 'legacy') {
+        expect(result.content).toEqual([{ type: 'text', text: JSON.stringify(payload) }]);
+      }
+    } finally {
+      await client.close();
+      await server.close();
+      sendRequest.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/__tests__/studio-handler-failures.test.ts
+++ b/packages/core/src/__tests__/studio-handler-failures.test.ts
@@ -8,6 +8,7 @@ import { createToolServer } from '../mcp-runtime.js';
 import { TOOL_HANDLERS } from '../http-server.js';
 import { RobloxStudioTools } from '../tools/index.js';
 import { TOOL_DEFINITIONS } from '../tools/definitions.js';
+import { StudioInstanceManager } from '../studio-instance-manager.js';
 
 // Execute the actual handler with only Roblox services/globals replaced. This
 // verifies its aggregate status without requiring a running Studio instance.
@@ -66,6 +67,8 @@ describe.each(['modern', 'legacy'] as const)('Studio handler failures over %s MC
     const bridge = new BridgeService();
     bridge.registerPeer({ peerId: 'edit', transportPeerId: 'edit', instanceId: 'instance:test', role: 'edit' });
     const sendRequest = jest.spyOn(bridge, 'sendRequest').mockResolvedValue(payload);
+    // Synthetic peers must not inspect or mutate the user's live launch registry.
+    const pendingLaunches = jest.spyOn(StudioInstanceManager.prototype, 'pendingLaunches').mockResolvedValue([]);
     const tools = new RobloxStudioTools(bridge);
     const definition = TOOL_DEFINITIONS.find(tool => tool.name === 'set_properties')!;
     const server = createToolServer({
@@ -92,6 +95,7 @@ describe.each(['modern', 'legacy'] as const)('Studio handler failures over %s MC
       await client.close();
       await server.close();
       sendRequest.mockRestore();
+      pendingLaunches.mockRestore();
     }
   });
 });

--- a/packages/core/src/mcp-runtime.ts
+++ b/packages/core/src/mcp-runtime.ts
@@ -159,6 +159,12 @@ export function normalizeToolResult(raw: unknown, era: ProtocolEra): CallToolRes
     };
   }
 
+  // Handler failures are returned as data, not necessarily thrown. Only inspect
+  // the response envelope: nested Luau return values and logs are ordinary data.
+  const isError = result.isError
+    || structured.success === false
+    || (typeof structured.error === 'string' && structured.error.length > 0);
+
   const content = era === 'modern'
     ? originalContent.filter((_, index) => index !== jsonTextIndex)
     : [
@@ -169,7 +175,7 @@ export function normalizeToolResult(raw: unknown, era: ProtocolEra): CallToolRes
   return {
     content: content as CallToolResult['content'],
     structuredContent: structured,
-    ...(result.isError ? { isError: true } : {}),
+    ...(isError ? { isError: true } : {}),
   };
 }
 

--- a/studio-plugin/src/modules/handlers/PropertyHandlers.ts
+++ b/studio-plugin/src/modules/handlers/PropertyHandlers.ts
@@ -64,6 +64,7 @@ function setProperties(requestData: Record<string, unknown>) {
 	finishRecording(recordingId, true);
 
 	return {
+		success: failureCount === 0,
 		instancePath,
 		summary: { total: successCount + failureCount, succeeded: successCount, failed: failureCount },
 		results,

--- a/tests/eval-bridge-error-preservation.mjs
+++ b/tests/eval-bridge-error-preservation.mjs
@@ -23,7 +23,7 @@ await runTest('eval_server_runtime preserves user error', async ({ track }) => {
 
   try {
     // Case 1: explicit error() with distinctive message
-    const r1 = await client.callTool('eval_server_runtime', {
+    const r1 = await client.callToolError('eval_server_runtime', {
       code: `error("${MARKER}-explicit-error")`,
     });
     assert(r1.ok === false, 'eval_server_runtime reports ok=false on error');
@@ -34,7 +34,7 @@ await runTest('eval_server_runtime preserves user error', async ({ track }) => {
       'response does NOT carry the generic require wrapper message');
 
     // Case 2: nil deref (different error class)
-    const r2 = await client.callTool('eval_server_runtime', {
+    const r2 = await client.callToolError('eval_server_runtime', {
       code: `local x = nil\nreturn x.${MARKER}_field`,
     });
     assert(r2.ok === false, 'nil deref reports ok=false');
@@ -74,7 +74,7 @@ return true
 `,
     });
 
-    const r3 = await client.callTool('eval_server_runtime', {
+    const r3 = await client.callToolError('eval_server_runtime', {
       code: `require(workspace.__MCPEvalNestedServerFailure)`,
     });
     assert(r3.ok === false, 'eval_server_runtime nested require reports failure');
@@ -83,7 +83,7 @@ return true
     assertNotContains(r3.error || '', GENERIC,
       'server nested require response does NOT use the generic require wrapper');
 
-    const r3Cached = await client.callTool('eval_server_runtime', {
+    const r3Cached = await client.callToolError('eval_server_runtime', {
       code: `require(workspace.__MCPEvalNestedServerFailure)`,
     });
     assert(r3Cached.ok === false, 'eval_server_runtime cached nested require reports failure');
@@ -92,7 +92,7 @@ return true
     assertNotContains(r3Cached.error || '', GENERIC,
       'server cached nested require response does NOT use the generic require wrapper');
 
-    const r4 = await client.callTool('eval_client_runtime', {
+    const r4 = await client.callToolError('eval_client_runtime', {
       target: 'client-1',
       code: `
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
@@ -106,7 +106,7 @@ require(module)
     assertNotContains(r4.error || '', GENERIC,
       'client nested require response does NOT use the generic require wrapper');
 
-    const r4Cached = await client.callTool('eval_client_runtime', {
+    const r4Cached = await client.callToolError('eval_client_runtime', {
       target: 'client-1',
       code: `
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
@@ -130,7 +130,7 @@ require(module)
     // Case 5: parse/compile error — engine collapses these into GENERIC
     // from pcall(require, m). Wrapper must recover the real parser
     // diagnostic from LogService.
-    const r6 = await client.callTool('eval_server_runtime', {
+    const r6 = await client.callToolError('eval_server_runtime', {
       code: `this is not valid luau syntax @#$`,
     });
     assert(r6.ok === false, 'eval_server_runtime parse error reports ok=false');
@@ -140,7 +140,7 @@ require(module)
       'parse-error response does NOT fall back to the generic require wrapper');
 
     // Case 6: parse error on client peer too
-    const r7 = await client.callTool('eval_client_runtime', {
+    const r7 = await client.callToolError('eval_client_runtime', {
       code: `!!! syntax error here`,
       target: 'client-1',
     });

--- a/tests/execute-luau-error-preservation.mjs
+++ b/tests/execute-luau-error-preservation.mjs
@@ -24,7 +24,7 @@ await runTest('execute_luau target=server preserves user error', async ({ track 
 
   try {
     // Case 1: explicit error() — works for target=edit, currently broken for target=server
-    const r1 = await client.callTool('execute_luau', {
+    const r1 = await client.callToolError('execute_luau', {
       target: 'server',
       code: `error("${MARKER}-server-error")`,
     });
@@ -39,7 +39,7 @@ await runTest('execute_luau target=server preserves user error', async ({ track 
     // Case 2: target=edit baseline — should already work, asserts the same
     // marker-preservation contract on the working path so we know our
     // assertions are sensible.
-    const r2 = await client.callTool('execute_luau', {
+    const r2 = await client.callToolError('execute_luau', {
       target: 'edit',
       code: `error("${MARKER}-edit-error")`,
     });
@@ -50,7 +50,7 @@ await runTest('execute_luau target=server preserves user error', async ({ track 
     // Case 3: nested ModuleScript load failures also go through require().
     // Roblox collapses these to GENERIC at the require boundary; execute_luau
     // should recover the real module-load diagnostic from LogService.
-    const r3 = await client.callTool('execute_luau', {
+    const r3 = await client.callToolError('execute_luau', {
       target: 'edit',
       code: `
 local module = Instance.new("ModuleScript")
@@ -91,7 +91,7 @@ return module:GetFullName()
     });
     assert(setupPreexisting.success === true, 'pre-existing failing module setup succeeds');
 
-    const r4 = await client.callTool('execute_luau', {
+    const r4 = await client.callToolError('execute_luau', {
       target: 'edit',
       code: `
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
@@ -104,7 +104,7 @@ require(ReplicatedStorage:WaitForChild("__MCPPreexistingRequireFailure"))
     assertNotContains(r4.error || '', GENERIC,
       'pre-existing require response does NOT use the generic require wrapper');
 
-    const r5 = await client.callTool('execute_luau', {
+    const r5 = await client.callToolError('execute_luau', {
       target: 'edit',
       code: `
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
@@ -130,7 +130,7 @@ require(ReplicatedStorage:WaitForChild("__MCPPreexistingRequireFailure"))
     // default forces the ModuleScript-fallback path, where require()
     // collapses parse errors into GENERIC). Handler must recover the real
     // parser diagnostic from LogService.
-    const r7 = await client.callTool('execute_luau', {
+    const r7 = await client.callToolError('execute_luau', {
       target: 'server',
       code: `this is not valid luau syntax @#$`,
     });

--- a/tests/large-input-workflow.mjs
+++ b/tests/large-input-workflow.mjs
@@ -19,6 +19,7 @@ await runTest('verified staged large-input workflow', async ({ track }) => {
     instance_id: instanceId, target: 'edit', operation_id: randomUUID(), code,
   });
   const invoke = step => client.callTool('execute_luau', step);
+  const reject = step => client.callToolError('execute_luau', step);
   const ok = async step => {
     const result = await invoke(step);
     assert.equal(result.success, true, JSON.stringify(result));
@@ -68,7 +69,7 @@ await runTest('verified staged large-input workflow', async ({ track }) => {
     }
   }
   async function rejectWithoutEffects(value) {
-    const result = await invoke(value.finalize());
+    const result = await reject(value.finalize());
     assert.equal(result.success, false, JSON.stringify(result));
     await truth(`return workspace:FindFirstChild(${luauString(value.outputName)}) == nil`);
     assert.equal(await ok(value.inspect()), 'uploading');
@@ -106,20 +107,20 @@ await runTest('verified staged large-input workflow', async ({ track }) => {
 
     const failed = transfer({ failure: 'runtime' });
     await upload(failed);
-    assert.equal((await invoke(failed.finalize())).success, false);
+    assert.equal((await reject(failed.finalize())).success, false);
     assert.equal(await ok(failed.inspect()), 'failed');
     await truth(failed.verification); // A known error did not roll back created geometry.
-    assert.equal((await invoke(failed.finalize())).success, false);
-    assert.equal((await invoke(failed.abort())).success, false);
+    assert.equal((await reject(failed.finalize())).success, false);
+    assert.equal((await reject(failed.abort())).success, false);
     await truth(`local root = game:GetService('ServerStorage')[${luauString(failed.rootName)}] return root:GetAttribute('Attempts') == 1 and root:FindFirstChild('Chunks') ~= nil`);
 
     const failedVerification = transfer({ failure: 'verification' });
     await upload(failedVerification);
-    assert.equal((await invoke(failedVerification.finalize())).success, false);
+    assert.equal((await reject(failedVerification.finalize())).success, false);
     assert.equal(await ok(failedVerification.inspect()), 'failed');
     await truth(failedVerification.effectsVerification);
-    assert.equal((await invoke(failedVerification.finalize())).success, false);
-    assert.equal((await invoke(failedVerification.abort())).success, false);
+    assert.equal((await reject(failedVerification.finalize())).success, false);
+    assert.equal((await reject(failedVerification.abort())).success, false);
     await truth(`local root = game:GetService('ServerStorage')[${luauString(failedVerification.rootName)}] return root:GetAttribute('Attempts') == 1 and root:FindFirstChild('Chunks') ~= nil`);
 
     const failedCompile = transfer({ failure: 'compile' });
@@ -131,7 +132,7 @@ await runTest('verified staged large-input workflow', async ({ track }) => {
     const foreign = transfer();
     await ok(foreign.begin());
     await raw(`local f = Instance.new('Folder') f.Name = 'Unowned' f.Parent = game:GetService('ServerStorage')[${luauString(foreign.rootName)}].Chunks return true`);
-    assert.equal((await invoke(foreign.abort())).success, false);
+    assert.equal((await reject(foreign.abort())).success, false);
     await truth(`return game:GetService('ServerStorage')[${luauString(foreign.rootName)}].Chunks:FindFirstChild('Unowned') ~= nil`);
     // The test created this sentinel; remove it explicitly, not through transfer cleanup.
     await raw(`game:GetService('ServerStorage')[${luauString(foreign.rootName)}].Chunks.Unowned:Destroy() return true`);
@@ -139,8 +140,8 @@ await runTest('verified staged large-input workflow', async ({ track }) => {
 
     const collision = transfer();
     await raw(`local f = Instance.new('Folder') f.Name = ${luauString(collision.rootName)} f.Parent = game:GetService('ServerStorage') return true`);
-    assert.equal((await invoke(collision.begin())).success, false);
-    assert.equal((await invoke(collision.abort())).success, false);
+    assert.equal((await reject(collision.begin())).success, false);
+    assert.equal((await reject(collision.abort())).success, false);
     await truth(`local f = game:GetService('ServerStorage'):FindFirstChild(${luauString(collision.rootName)}) return f ~= nil and f:GetAttribute('Owner') == nil`);
     await raw(`game:GetService('ServerStorage')[${luauString(collision.rootName)}]:Destroy() return true`);
     console.log(JSON.stringify({ cases: ['http-geometry-once', 'missing', 'tampered', 'reordered', 'failed-partial-effects-no-replay', 'failed-verification-no-replay', 'compile-failure-zero-effects', 'abort', 'unowned-descendant', 'unowned-root'], chunks: success.chunkCount }));

--- a/tests/lib/mcp-client.mjs
+++ b/tests/lib/mcp-client.mjs
@@ -209,9 +209,8 @@ export class McpClient {
     this.notify('notifications/initialized', {});
   }
 
-  /** tools/call wrapper. Returns the parsed first text-content body (the
-      common shape used by the Roblox Studio MCP). Throws if no text content. */
-  async callTool(name, args = {}, timeoutMs = 30_000) {
+  /** Return the parsed body and protocol status for tests of either outcome. */
+  async callToolResult(name, args = {}, timeoutMs = 30_000) {
     const routedArgs = { ...args };
     if (
       process.env.MCP_INSTANCE_ID &&
@@ -226,14 +225,28 @@ export class McpClient {
     if (text == null) {
       throw new Error(`Tool ${name} returned no text content: ${JSON.stringify(res)}`);
     }
-    if (res?.isError) {
-      throw new Error(`Tool ${name} returned isError: ${text}`);
-    }
     try {
-      return JSON.parse(text);
+      return { body: JSON.parse(text), isError: res.isError === true };
     } catch {
-      return text;
+      return { body: text, isError: res.isError === true };
     }
+  }
+
+  /** Successful calls remain fail-fast; expected failures must opt in. */
+  async callTool(name, args = {}, timeoutMs = 30_000) {
+    const result = await this.callToolResult(name, args, timeoutMs);
+    if (result.isError) {
+      throw new Error(`Tool ${name} returned isError: ${JSON.stringify(result.body)}`);
+    }
+    return result.body;
+  }
+
+  async callToolError(name, args = {}, timeoutMs = 30_000) {
+    const result = await this.callToolResult(name, args, timeoutMs);
+    if (!result.isError) {
+      throw new Error(`Tool ${name} did not return isError: true: ${JSON.stringify(result.body)}`);
+    }
+    return result.body;
   }
 
   async stop() {

--- a/tests/mcp-client-output-parser.mjs
+++ b/tests/mcp-client-output-parser.mjs
@@ -38,6 +38,8 @@ async function fixture() {
       await writeOutput(unicodeBytes.subarray(1));
       for (let offset = 0; offset < LARGE_BYTES; offset += CHUNK.length) await writeOutput(CHUNK);
       await writeOutput('"}}\n');
+    } else if (request.method === 'tools/call') {
+      await writeOutput(`${JSON.stringify({ jsonrpc: '2.0', id: request.id, result: request.params.arguments.response })}\n`);
     } else {
       await writeOutput(`${JSON.stringify({ jsonrpc: '2.0', id: request.id, result: request.params })}\n`);
     }
@@ -57,6 +59,15 @@ async function regression() {
       client.rpc('paired', first), client.rpc('paired', second),
     ]);
     assert.deepEqual(paired, [first, second], 'Coalesced responses resolve by ID despite reversed order and framing noise');
+
+    const failureBody = { success: false, error: 'Expected handler failure', summary: { succeeded: 1, failed: 1 } };
+    const failure = { response: { isError: true, content: [{ type: 'text', text: JSON.stringify(failureBody) }] } };
+    const success = { response: { content: [{ type: 'text', text: '{"success":true}' }] } };
+    assert.deepEqual(await client.callToolResult('fixture', failure), { body: failureBody, isError: true });
+    assert.deepEqual(await client.callToolError('fixture', failure), failureBody);
+    await assert.rejects(client.callTool('fixture', failure), /returned isError/);
+    await assert.rejects(client.callToolError('fixture', success), /did not return isError: true/);
+    assert.deepEqual(await client.callTool('fixture', success), { success: true });
 
     const expectedHash = createHash('sha256').update(UNICODE);
     for (let offset = 0; offset < LARGE_BYTES; offset += CHUNK.length) expectedHash.update(CHUNK);

--- a/tests/property-value-conversion.mjs
+++ b/tests/property-value-conversion.mjs
@@ -113,6 +113,30 @@ return true
     const positionResult = findResult(positionSet, 'Position');
     assert(positionSet.summary?.failed === 0 && positionResult?.success === true,
       'set_properties preserves {X,Y,Z} for Vector3 properties');
+
+    const missing = await client.callToolError('set_properties', {
+      instancePath: `${partPath}.Missing`,
+      properties: { Anchored: true },
+      instance_id: instanceId,
+    });
+    assert(missing.error?.includes('Instance not found'), 'missing instance is an MCP error with its handler diagnostic');
+
+    const partial = await client.callToolError('set_properties', {
+      instancePath: partPath,
+      properties: { Anchored: true, __InvalidProperty: true },
+      instance_id: instanceId,
+    });
+    assert(partial.success === false && partial.summary?.succeeded === 1 && partial.summary?.failed === 1,
+      'partial property write is an MCP error with accurate counts');
+    assert(findResult(partial, 'Anchored')?.success === true
+      && typeof findResult(partial, '__InvalidProperty')?.error === 'string',
+    'partial property write preserves successful results and failure details');
+    const readback = await client.callTool('execute_luau', {
+      target: 'edit',
+      instance_id: instanceId,
+      code: `return workspace.__RSMCP_Vector3Conversion.Anchored`,
+    });
+    assert(String(readback.returnValue) === 'true', 'a failed batch does not roll back successful property writes');
   } finally {
     await cleanupProbes(client, instanceId);
     if (launchedInstanceId) {

--- a/tests/studio-grep-responsiveness.mjs
+++ b/tests/studio-grep-responsiveness.mjs
@@ -82,7 +82,7 @@ return root ~= nil
 async function waitForReleasedSearch(client, instanceId, deadline) {
   let last;
   while (Date.now() < deadline) {
-    last = await client.callTool('grep_scripts', {
+    const result = await client.callToolResult('grep_scripts', {
       instance_id: instanceId,
       pattern: 'RSMCP_NEEDLE_0001',
       caseSensitive: true,
@@ -91,7 +91,9 @@ async function waitForReleasedSearch(client, instanceId, deadline) {
       path: FIXTURE_PATH,
       classFilter: 'ModuleScript',
     }, 15_000);
-    if (last?.error !== 'plugin_busy') return last;
+    last = result.body;
+    assert(result.isError === (last?.error === 'plugin_busy'), 'only plugin_busy is an expected search failure');
+    if (!result.isError) return last;
     await delay(25);
   }
   throw new Error(`cancelled grep did not release its exclusive job: ${JSON.stringify(last)}`);
@@ -130,7 +132,7 @@ await runTest('large external grep remains responsive and cancellable', async ({
     const probeStartedAt = Date.now();
     const [placeInfo, overlap] = await Promise.all([
       client.callTool('get_place_info', { instance_id: instanceId }, 10_000),
-      client.callTool('grep_scripts', {
+      client.callToolError('grep_scripts', {
         instance_id: instanceId,
         pattern: 'different-pattern',
         caseSensitive: true,


### PR DESCRIPTION
## Summary
- Propagate explicit handler failures into MCP isError while preserving details and partial writes.
- Add unit and live failure coverage; expected-error tests now require the protocol flag.
- Isolate synthetic test peers from the real launch registry.

## Validation
- Build, typecheck, and plugin compilation pass.
- Core: 36 suites, 616 tests passed on the combined latest-main candidate.
- Test runner suite passed.
- Feature gate (npm run test:e2e): 3/3 passed.
- Full live gate (npm run test:studio:runner): 20/20 passed, including a final rerun after integrating PR #83 from main.
- Live coverage verifies missing-instance errors, partial-write details and readback, and error preservation across edit/server/client execution.

Earlier runs exposed outdated expected-error test calls (fixed) and intermittent Studio lifecycle/timeouts; final full runs passed twice consecutively.

Closes #79