### PR TITLE
fix: preserve user-defined keys in tool result payloads

### DIFF
--- a/packages/core/src/__tests__/mcp-runtime.test.ts
+++ b/packages/core/src/__tests__/mcp-runtime.test.ts
@@ -96,6 +96,50 @@ describe('MCP v2 tool runtime', () => {
       nested: { warnings: [] },
     });
   });
+
+  describe.each(['modern', 'legacy'] as const)('%s user-defined result keys', (era) => {
+    test.each(['text', 'structuredContent'] as const)('preserves nested keys from %s while removing envelope metadata', (source) => {
+      const attributes = Object.fromEntries([
+        'bundleModifiedAt', 'bundlePath', 'bundleSha256', 'connectedAt',
+        'debug', 'diagnostics', 'internal', 'lastActivity', 'transportPeerId',
+        'pluginVariant', 'pluginVersion', 'serverVersion',
+      ].map((name) => [name, { value: name, type: 'string' }]));
+      const payload = {
+        instancePath: 'game.Workspace.Part',
+        count: Object.keys(attributes).length,
+        attributes,
+        results: [{ properties: { debug: false, internal: null, diagnostics: [] } }],
+      };
+      const envelope = {
+        ...payload,
+        transportPeerId: 'private-peer',
+        diagnostics: { elapsed: 10 },
+        internal: { secret: 'private' },
+      };
+      const original = JSON.stringify(envelope);
+      const result = normalizeToolResult(source === 'text'
+        ? { content: [{ type: 'text', text: original }] }
+        : { structuredContent: envelope }, era);
+
+      expect(result.structuredContent).toEqual(payload);
+      expect(result.content).toEqual(era === 'modern'
+        ? []
+        : [{ type: 'text', text: JSON.stringify(payload) }]);
+      expect(JSON.stringify(envelope)).toBe(original);
+    });
+
+    test('preserves prototype-like user keys as own JSON properties', () => {
+      const payload = JSON.parse('{"__proto__":{"value":"root"},"attributes":{"__proto__":{"value":"nested"},"constructor":{"value":"ctor"},"toString":{"value":"string"}}}');
+      const result = normalizeToolResult({
+        content: [{ type: 'text', text: JSON.stringify(payload) }],
+      }, era);
+
+      expect(result.structuredContent).toEqual(payload);
+      expect(JSON.stringify(result.structuredContent)).toBe(JSON.stringify(payload));
+      expect(Object.getPrototypeOf(result.structuredContent)).toBe(Object.prototype);
+    });
+  });
+
   test('serializes routing choices as compact role-keyed Peer maps', () => {
     const failure = new RoutingFailure({
       code: 'multiple_instances_connected',

--- a/packages/core/src/mcp-runtime.ts
+++ b/packages/core/src/mcp-runtime.ts
@@ -48,20 +48,20 @@ type ToolResultLike = {
   isError?: boolean;
 };
 
-const INTERNAL_RESULT_KEYS = new Set([
-  'bundleModifiedAt',
-  'bundlePath',
-  'bundleSha256',
-  'connectedAt',
-  'debug',
-  'diagnostics',
-  'internal',
-  'lastActivity',
-  'transportPeerId',
-  'pluginVariant',
-  'pluginVersion',
-  'serverVersion',
-]);
+const INTERNAL_ENVELOPE_KEYS: Record<string, true> = {
+  bundleModifiedAt: true,
+  bundlePath: true,
+  bundleSha256: true,
+  connectedAt: true,
+  debug: true,
+  diagnostics: true,
+  internal: true,
+  lastActivity: true,
+  transportPeerId: true,
+  pluginVariant: true,
+  pluginVersion: true,
+  serverVersion: true,
+};
 
 const TEXT_RESULT_TOOLS = new Set(['get_roblox_docs']);
 // These remain in the inspector catalog because they do not mutate the
@@ -113,17 +113,24 @@ function compactPublicValue(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(compactPublicValue);
   if (!value || typeof value !== 'object') return value;
 
-  const compact: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(value)) {
-    if (child === undefined || INTERNAL_RESULT_KEYS.has(key)) continue;
-    compact[key] = compactPublicValue(child);
-  }
-  return compact;
+  // Nested objects can contain user-defined keys (attributes, properties, etc.).
+  // Only omit undefined values; fromEntries also preserves own "__proto__" keys.
+  return Object.fromEntries(Object.entries(value)
+    .filter(([, child]) => child !== undefined)
+    .map(([key, child]) => [key, compactPublicValue(child)]));
+}
+
+function compactPublicEnvelope(value: object): Record<string, unknown> {
+  // Metadata names are reserved on the tool response envelope, not its payload.
+  // Producers of nested server metadata must explicitly project public fields.
+  return Object.fromEntries(Object.entries(value)
+    .filter(([key, child]) => child !== undefined && !Object.hasOwn(INTERNAL_ENVELOPE_KEYS, key))
+    .map(([key, child]) => [key, compactPublicValue(child)]));
 }
 
 function asStructuredObject(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
-  return compactPublicValue(value) as Record<string, unknown>;
+  return compactPublicEnvelope(value);
 }
 
 function parseJsonObject(text: string): Record<string, unknown> | undefined {
@@ -198,7 +205,7 @@ export function publicToolErrorBody(name: string, error: unknown): Record<string
     return { error: error.code, message: error.message, multiplayer_group_id: error.groupId };
   }
   if (error instanceof StudioLaunchPreDispatchError) {
-    return compactPublicValue(error.toResponseBody()) as Record<string, unknown>;
+    return compactPublicEnvelope(error.toResponseBody());
   }
   if (error instanceof RoutingFailure) return publicRoutingError(error);
   if (error instanceof RequestFailure) {


### PR DESCRIPTION
## Summary
- Restrict internal metadata filtering to the response envelope, preserving nested user-defined attribute/property keys and array contents.
- Preserve own prototype-like JSON keys using safe object copying.
- Cover both modern and legacy clients and JSON-text/structured inputs with six regression cases.

## Validation
- npm run build: passed.
- Runtime and HTTP-security Jest suites: 63/63 passed after integrating current main.
- npm run test:studio:runner: final full live Studio gate passed 20/20, including managed Studio cleanup.
- Earlier live attempts passed 17/20 and 19/20 with varying simulation/multiplayer lifecycle failures; the final fresh-session run passed without code changes or skipped tests.
- Typecheck passed; targeted lint had zero errors and one pre-existing test warning.

Closes #78