### PR TITLE
feat(capture): capture screenshots through StudioCaptureService

### DIFF
--- a/packages/core/src/__tests__/http-security.test.ts
+++ b/packages/core/src/__tests__/http-security.test.ts
@@ -98,6 +98,47 @@ describe('HTTP security', () => {
           await app.cleanup();
         }
       });
+
+    it('forwards Studio captures when capture_screenshot is enabled', async () => {
+      const app = createHttpServer(tools, bridge, new Set(['capture_screenshot']),
+        undefined, { authToken: token });
+      const capture = {
+        success: true, encoding: 'png', source: 'StudioCaptureService',
+        width: 1, height: 1, nativeWidth: 1, nativeHeight: 1,
+        data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aN1cAAAAASUVORK5CYII=',
+      };
+      const dispatch = jest.spyOn(bridge, 'sendRequest').mockResolvedValue(capture);
+      try {
+        const response = await request(app).post('/proxy').set('Authorization', `Bearer ${token}`)
+          .send({ endpoint: '/api/capture-studio', data: { encoding: 'png' },
+            targetPeerId: 'studio-peer', timeoutMs: 1000, operationId: 'capture-operation' });
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({ response: capture });
+        expect(dispatch).toHaveBeenCalledWith('/api/capture-studio', { encoding: 'png' },
+          'studio-peer', 1000, expect.any(AbortSignal), 'capture-operation');
+      } finally {
+        dispatch.mockRestore();
+        await app.cleanup();
+      }
+    });
+
+    it('rejects Studio captures when capture_screenshot is disabled', async () => {
+      const allowed = new Set(getReadOnlyTools().map(tool => tool.name));
+      allowed.delete('capture_screenshot');
+      const app = createHttpServer(tools, bridge, allowed, undefined, { authToken: token });
+      const dispatch = jest.spyOn(bridge, 'sendRequest').mockResolvedValue({ success: true });
+      try {
+        const response = await request(app).post('/proxy').set('Authorization', `Bearer ${token}`)
+          .send({ endpoint: '/api/capture-studio', data: { encoding: 'png' },
+            targetPeerId: 'studio-peer' });
+        expect(response.status).toBe(403);
+        expect(response.body.error).toBe('forbidden_endpoint');
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        dispatch.mockRestore();
+        await app.cleanup();
+      }
+    });
   });
 
   describe('origin policy', () => {

--- a/packages/core/src/__tests__/smoke.test.ts
+++ b/packages/core/src/__tests__/smoke.test.ts
@@ -4273,7 +4273,7 @@ describe('Smoke', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     const capturePending = claimQueuedRequest(bridge, 'session-1');
-    expect(capturePending?.request).toMatchObject({ endpoint: '/api/capture-screenshot' });
+    expect(capturePending?.request).toMatchObject({ endpoint: '/api/capture-studio' });
     bridge.resolveRequest(capturePending!.requestId, { error: 'screenshot boom' });
 
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -4379,7 +4379,7 @@ describe('Smoke', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     const capturePending = claimQueuedRequest(bridge, 'session-1');
-    expect(capturePending?.request).toMatchObject({ endpoint: '/api/capture-screenshot' });
+    expect(capturePending?.request).toMatchObject({ endpoint: '/api/capture-studio' });
     bridge.resolveRequest(capturePending!.requestId, {
       width: 1,
       height: 1,
@@ -4423,7 +4423,7 @@ describe('Smoke', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     const capturePending = claimQueuedRequest(bridge, 'session-1');
-    expect(capturePending?.request).toMatchObject({ endpoint: '/api/capture-screenshot' });
+    expect(capturePending?.request).toMatchObject({ endpoint: '/api/capture-studio' });
     bridge.resolveRequest(capturePending!.requestId, {
       width: 3,
       height: 1,
@@ -4439,6 +4439,130 @@ describe('Smoke', () => {
     expect(meta).toMatchObject({ width: 3, height: 1, format: 'jpeg' });
     expect(meta.message).toContain('downscaled from the 4x2 viewport');
     expect(meta.message).toContain('multiply x read off this image by 1.3333 and y by 2.0000');
+  });
+
+  test('capture_screenshot falls back to CaptureService when StudioCaptureService is unavailable', async () => {
+    const bridge = new BridgeService();
+    const tools = new RobloxStudioTools(bridge);
+    bridge.registerPeer(READY);
+
+    const resultPromise = tools.captureScreenshot('instance:test', 'jpeg', 80);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const studioPending = claimQueuedRequest(bridge, 'session-1');
+    expect(studioPending?.request).toMatchObject({ endpoint: '/api/capture-studio' });
+    bridge.resolveRequest(studioPending!.requestId, { unavailable: 'no flag' });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const legacyPending = claimQueuedRequest(bridge, 'session-1');
+    expect(legacyPending?.request).toMatchObject({ endpoint: '/api/capture-screenshot' });
+    bridge.resolveRequest(legacyPending!.requestId, {
+      width: 1,
+      height: 1,
+      data: Buffer.from([12, 34, 56, 255]).toString('base64'),
+    });
+
+    const result = await resultPromise;
+    const firstContent = result.content[0];
+    if (firstContent.type !== 'text' || firstContent.text === undefined) throw new Error('Expected screenshot metadata text first');
+    expect(JSON.parse(firstContent.text)).toMatchObject({ width: 1, height: 1, format: 'jpeg' });
+    expect(result.content.some((item) => item.type === 'image')).toBe(true);
+  });
+
+  test('capture_screenshot falls back when the installed plugin has no capture-studio endpoint', async () => {
+    const bridge = new BridgeService();
+    const tools = new RobloxStudioTools(bridge);
+    bridge.registerPeer(READY);
+
+    const resultPromise = tools.captureScreenshot('instance:test', 'jpeg', 80);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const studioPending = claimQueuedRequest(bridge, 'session-1');
+    bridge.resolveRequest(studioPending!.requestId, { error: 'Unknown endpoint: /api/capture-studio' });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const legacyPending = claimQueuedRequest(bridge, 'session-1');
+    expect(legacyPending?.request).toMatchObject({ endpoint: '/api/capture-screenshot' });
+    bridge.resolveRequest(legacyPending!.requestId, {
+      width: 1,
+      height: 1,
+      data: Buffer.from([9, 9, 9, 255]).toString('base64'),
+    });
+
+    const result = await resultPromise;
+    expect(result.content.some((item) => item.type === 'image')).toBe(true);
+  });
+
+  test('capture_screenshot runs the studio fast path in the play client peer', async () => {
+    const bridge = new BridgeService();
+    const tools = new RobloxStudioTools(bridge);
+    bridge.registerPeer(READY);
+    bridge.registerPeer({
+      peerId: 'client-1',
+      transportPeerId: 'client-session',
+      instanceId: 'instance:test',
+      role: 'client',
+      placeId: 0,
+      placeName: 'TestPlace',
+      dataModelName: 'Game',
+      isRunning: true,
+    });
+
+    const resultPromise = tools.captureScreenshot('instance:test', 'jpeg', 80);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const studioPending = claimQueuedRequest(bridge, 'client-session');
+    expect(studioPending?.request).toMatchObject({ endpoint: '/api/capture-studio', data: { encoding: 'rgba8' } });
+    bridge.resolveRequest(studioPending!.requestId, { unavailable: 'no flag' });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const beginPending = claimQueuedRequest(bridge, 'client-session');
+    expect(beginPending?.request).toMatchObject({ endpoint: '/api/capture-begin' });
+    bridge.resolveRequest(beginPending!.requestId, { contentId: 'rbxtemp://1' });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const readPending = claimQueuedRequest(bridge, 'session-1');
+    expect(readPending?.request).toMatchObject({ endpoint: '/api/capture-read' });
+    bridge.resolveRequest(readPending!.requestId, {
+      width: 1,
+      height: 1,
+      data: Buffer.from([1, 2, 3, 255]).toString('base64'),
+    });
+
+    const result = await resultPromise;
+    expect(result.content.some((item) => item.type === 'image')).toBe(true);
+  });
+
+  test('capture_screenshot returns the PNG encoded in Studio without re-encoding it', async () => {
+    const bridge = new BridgeService();
+    const tools = new RobloxStudioTools(bridge);
+    bridge.registerPeer(READY);
+
+    const resultPromise = tools.captureScreenshot('instance:test', 'png');
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const studioPending = claimQueuedRequest(bridge, 'session-1');
+    expect(studioPending?.request).toMatchObject({ endpoint: '/api/capture-studio', data: { encoding: 'png' } });
+
+    // 1x1 red PNG produced by Studio; the server must pass these bytes through.
+    const pngBytes = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==',
+      'base64',
+    );
+    bridge.resolveRequest(studioPending!.requestId, {
+      success: true,
+      encoding: 'png',
+      source: 'StudioCaptureService',
+      width: 1,
+      height: 1,
+      data: pngBytes.toString('base64'),
+    });
+
+    const result = await resultPromise;
+    const image = result.content.find((item) => item.type === 'image');
+    if (!image || image.type !== 'image') throw new Error('Expected an image content item');
+    expect(image.mimeType).toBe('image/png');
+    expect(image.data).toBe(pngBytes.toString('base64'));
   });
 
   test('capture_device_matrix keeps the total inline image payload within the aggregate budget', async () => {
@@ -4491,7 +4615,7 @@ describe('Smoke', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 0));
       const capturePending = claimQueuedRequest(bridge, 'session-1');
-      expect(capturePending?.request).toMatchObject({ endpoint: '/api/capture-screenshot' });
+      expect(capturePending?.request).toMatchObject({ endpoint: '/api/capture-studio' });
       bridge.resolveRequest(capturePending!.requestId, {
         width: noiseSide,
         height: noiseSide,

--- a/packages/core/src/http-server.ts
+++ b/packages/core/src/http-server.ts
@@ -78,7 +78,7 @@ const TOOL_PROXY_ENDPOINTS: Record<string, readonly string[]> = {
   insert_asset: ['/api/insert-asset'],
   generate_model: ['/api/generate-model'],
   preview_asset: ['/api/preview-asset'],
-  capture_screenshot: ['/api/capture-screenshot', '/api/capture-begin', '/api/capture-read'],
+  capture_screenshot: ['/api/capture-studio', '/api/capture-screenshot', '/api/capture-begin', '/api/capture-read'],
   simulate_mouse_input: ['/api/simulate-mouse-input'],
   simulate_keyboard_input: ['/api/simulate-keyboard-input'],
   get_memory_breakdown: ['/api/get-memory-breakdown'],

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -28,6 +28,9 @@ import * as path from 'path';
 type RawImageCaptureResponse = {
   success?: boolean;
   error?: string;
+  unavailable?: string;
+  encoding?: 'rgba8' | 'png';
+  source?: string;
   width?: number;
   height?: number;
   nativeWidth?: number;
@@ -4982,24 +4985,55 @@ export class RobloxStudioTools {
     quality?: number,
     maxBytes: number = MAX_INLINE_IMAGE_BYTES,
   ): Promise<EncodedViewportCapture> {
-    let response: RawImageCaptureResponse;
-    if (targetRole.startsWith('client-')) {
-      // Play mode. The running game VM can trigger CaptureScreenshot but can't
-      // read the resulting temp texture back (privilege gate). So capture on
-      // the client to get the rbxtemp:// id, then read it back in the edit DM —
-      // the rbxtemp handle is process-scoped and the edit/plugin identity is
-      // allowed to promote it into a readable EditableImage.
-      const begin = await this._callSingle('/api/capture-begin', {}, targetRole, instanceId) as { contentId?: string; error?: string };
-      if (begin.error) {
-        return { success: false, error: begin.error };
+    const fmt: 'jpeg' | 'png' = format === 'png' ? 'png' : 'jpeg';
+    const q = quality === undefined ? 92 : Math.max(1, Math.min(100, Math.floor(quality)));
+
+    // Fast path: StudioCaptureService (Studio-only, FFlag-gated) reads the
+    // framebuffer directly — no CaptureService callback, no EditableImage
+    // promotion, no client-to-edit temp-texture handoff — and it captures what
+    // Studio renders, SurfaceGui.AlwaysOnTop included (the legacy path misses
+    // that layer).
+    //
+    // It MUST run in the DataModel that is being rendered. Verified live: with
+    // a playtest active the edit peer still reports CanCaptureScreenshot()
+    // true, yet the capture never leaves BufferStatus.Pending (no errors, even
+    // after the playtest stops), while the same call in the play client peer
+    // completes. So the request follows targetRole, which is already the
+    // rendering peer: 'edit' when idle, 'client-N' during a playtest.
+    let response = await this._callSingle(
+      '/api/capture-studio',
+      { encoding: fmt === 'png' ? 'png' : 'rgba8' },
+      targetRole,
+      instanceId,
+    ) as RawImageCaptureResponse;
+
+    // A plugin older than this server rejects the endpoint outright — from the
+    // edit peer as "Unknown endpoint", from the play client as "Unsupported
+    // client broker endpoint". Both mean the fast path is absent, same as
+    // `unavailable`.
+    const studioFastPathMissing =
+      response.unavailable !== undefined ||
+      (response.error?.includes('/api/capture-studio') ?? false);
+
+    if (studioFastPathMissing) {
+      if (targetRole.startsWith('client-')) {
+        // Play mode. The running game VM can trigger CaptureScreenshot but can't
+        // read the resulting temp texture back (privilege gate). So capture on
+        // the client to get the rbxtemp:// id, then read it back in the edit DM —
+        // the rbxtemp handle is process-scoped and the edit/plugin identity is
+        // allowed to promote it into a readable EditableImage.
+        const begin = await this._callSingle('/api/capture-begin', {}, targetRole, instanceId) as { contentId?: string; error?: string };
+        if (begin.error) {
+          return { success: false, error: begin.error };
+        }
+        if (!begin.contentId) {
+          return { success: false, error: 'Screenshot capture failed: no content id returned from client.' };
+        }
+        response = await this._callSingle('/api/capture-read', { contentId: begin.contentId }, 'edit', instanceId) as RawImageCaptureResponse;
+      } else {
+        // Edit mode: capture and read back in the same (edit) context.
+        response = await this._callSingle('/api/capture-screenshot', {}, 'edit', instanceId) as RawImageCaptureResponse;
       }
-      if (!begin.contentId) {
-        return { success: false, error: 'Screenshot capture failed: no content id returned from client.' };
-      }
-      response = await this._callSingle('/api/capture-read', { contentId: begin.contentId }, 'edit', instanceId) as RawImageCaptureResponse;
-    } else {
-      // Edit mode: capture and read back in the same (edit) context.
-      response = await this._callSingle('/api/capture-screenshot', {}, 'edit', instanceId) as RawImageCaptureResponse;
     }
 
     if (response.error) {
@@ -5024,9 +5058,6 @@ export class RobloxStudioTools {
       return { success: false, error: 'Screenshot response missing dimensions.' };
     }
 
-    const fmt: 'jpeg' | 'png' = format === 'png' ? 'png' : 'jpeg';
-    const q = quality === undefined ? 92 : Math.max(1, Math.min(100, Math.floor(quality)));
-
     // Cap the inline image size. Measured empirically: an ~8MB image (11MB
     // base64) returns fine, but ~16MB (22MB base64) CLOSES the MCP connection
     // and drops every Studio registration — a catastrophic failure, not a
@@ -5034,9 +5065,20 @@ export class RobloxStudioTools {
     // For PNG we refuse (rather than silently dropping the lossless guarantee
     // the caller asked for); for JPEG we step quality down so the call still
     // succeeds.
-    const encoded = encodeImageFromRgbaResponse(response, fmt, q);
-    let { buffer } = encoded;
-    const { mimeType } = encoded;
+    let buffer: Buffer;
+    let mimeType: string;
+    if (response.encoding === 'png') {
+      // StudioCaptureService already encoded the PNG in Studio.
+      if (!response.data) {
+        return { success: false, error: 'Screenshot response missing PNG data.' };
+      }
+      buffer = Buffer.from(response.data, 'base64');
+      mimeType = 'image/png';
+    } else {
+      const encoded = encodeImageFromRgbaResponse(response, fmt, q);
+      buffer = encoded.buffer;
+      mimeType = encoded.mimeType;
+    }
     let usedQ = q;
     let note = '';
 

--- a/studio-plugin/src/modules/CaptureTransfer.ts
+++ b/studio-plugin/src/modules/CaptureTransfer.ts
@@ -1,0 +1,215 @@
+// Private ClientBroker transport. Only metadata and <=1 MiB data chunks cross
+// InvokeClient; callers still receive the original capture-studio response.
+const HttpService = game.GetService("HttpService");
+const READ_ENDPOINT = "/__mcp/capture-studio/read";
+const RELEASE_ENDPOINT = "/__mcp/capture-studio/release";
+const CHUNK_BYTES = 1024 * 1024;
+const MAX_TRANSFER_BYTES = 64 * 1024 * 1024;
+const MAX_TRANSFERS = 2;
+const TRANSFER_TTL_SECONDS = 60;
+
+interface CaptureMetadata {
+	success: true;
+	encoding: "png" | "rgba8";
+	source: "StudioCaptureService";
+	width: number;
+	height: number;
+	nativeWidth: number;
+	nativeHeight: number;
+}
+
+interface Transfer {
+	data?: string;
+	offset: number;
+	expiresAt: number;
+	expiryThread?: thread;
+}
+
+type Invoke = (endpoint: string, data: Record<string, unknown>) => unknown;
+const transfers = new Map<string, Transfer>();
+
+function integer(value: unknown, min: number, max: number): value is number {
+	return typeIs(value, "number") && value >= min && value <= max && value === math.floor(value);
+}
+
+function validId(value: unknown): value is string {
+	return typeIs(value, "string") && value.size() > 0 && value.size() <= 64;
+}
+
+function metadata(value: unknown): CaptureMetadata | undefined {
+	if (!typeIs(value, "table")) return undefined;
+	const fields = value as Record<string, unknown>;
+	if (
+		fields.success !== true ||
+		(fields.encoding !== "png" && fields.encoding !== "rgba8") ||
+		fields.source !== "StudioCaptureService" ||
+		!integer(fields.width, 1, 65536) || !integer(fields.height, 1, 65536) ||
+		!integer(fields.nativeWidth, 1, 65536) || !integer(fields.nativeHeight, 1, 65536)
+	) return undefined;
+	return {
+		success: true, encoding: fields.encoding, source: fields.source,
+		width: fields.width, height: fields.height,
+		nativeWidth: fields.nativeWidth, nativeHeight: fields.nativeHeight,
+	};
+}
+
+function fail(message: string): { success: false; error: string } {
+	return { success: false, error: `Capture transfer: ${message}` };
+}
+
+function discard(id: string): void {
+	const transfer = transfers.get(id);
+	if (transfer === undefined) return;
+	transfers.delete(id);
+	if (transfer.expiryThread !== undefined) task.cancel(transfer.expiryThread);
+}
+
+function prune(): void {
+	const now = os.clock();
+	for (const [id, transfer] of transfers) {
+		if (now >= transfer.expiresAt) discard(id);
+	}
+}
+
+function release(data: Record<string, unknown>): unknown {
+	if (!validId(data.transferId)) return fail("invalid transfer ID");
+	discard(data.transferId);
+	// Idempotent release also negotiates chunk support before capture starts.
+	return { success: true, chunkBytes: CHUNK_BYTES };
+}
+
+function begin(data: Record<string, unknown>, capture: () => unknown): unknown {
+	prune();
+	const id = data.transferId;
+	// An older server cannot consume chunk descriptors. Let it use legacy
+	// capture rather than returning an unsafe inline image or a hard error.
+	if (id === undefined) return { unavailable: "Client capture requires bounded transfer support" };
+	if (!validId(id)) return fail("invalid transfer ID");
+	if (transfers.has(id)) return fail("duplicate transfer ID");
+	// Reserve before capture yields: concurrent captures cannot over-admit or
+	// evict each other's data. Retained strings are capped at 2 * 64 MiB.
+	if (transfers.size() >= MAX_TRANSFERS) return fail("two captures are already in flight; release or await them first");
+	const transfer: Transfer = { offset: 0, expiresAt: os.clock() + TRANSFER_TTL_SECONDS };
+	transfers.set(id, transfer);
+	// Capture only the ID, not the large payload, in the expiry closure.
+	transfer.expiryThread = task.delay(TRANSFER_TTL_SECONDS, () => {
+		const current = transfers.get(id);
+		if (current !== undefined && os.clock() >= current.expiresAt) {
+			current.expiryThread = undefined;
+			discard(id);
+		}
+	});
+	const [ok, result] = pcall(capture);
+	if (!ok) {
+		if (transfers.get(id) === transfer) discard(id);
+		return fail(`capture failed: ${tostring(result)}`);
+	}
+	if (transfers.get(id) !== transfer || os.clock() >= transfer.expiresAt) {
+		if (transfers.get(id) === transfer) discard(id);
+		return fail("capture expired before it completed");
+	}
+	const info = metadata(result);
+	if (info === undefined) {
+		discard(id);
+		// Unavailability must reach core unchanged to preserve legacy fallback.
+		if (typeIs(result, "table")) {
+			const fields = result as Record<string, unknown>;
+			if (typeIs(fields.unavailable, "string")) return { unavailable: fields.unavailable.sub(1, 4096) };
+			if (typeIs(fields.error, "string")) return fail(fields.error.sub(1, 4096));
+		}
+		return fail("invalid capture response");
+	}
+	const fields = result as Record<string, unknown>;
+	const pixels = fields.data;
+	if (!typeIs(pixels, "string") || !validSize(pixels.size(), info)) {
+		discard(id);
+		return fail("invalid or oversized capture data");
+	}
+	transfer.data = pixels;
+	return {
+		transferId: id, totalBytes: pixels.size(), chunkBytes: CHUNK_BYTES,
+		metadata: info,
+	};
+}
+
+function validSize(size: unknown, info: CaptureMetadata): size is number {
+	if (!integer(size, 4, MAX_TRANSFER_BYTES) || size % 4 !== 0) return false;
+	return info.encoding !== "rgba8" || size === math.ceil(info.width * info.height * 4 / 3) * 4;
+}
+
+function read(data: Record<string, unknown>): unknown {
+	prune();
+	const id = data.transferId;
+	if (!validId(id)) return fail("invalid transfer ID");
+	const transfer = transfers.get(id);
+	if (transfer === undefined) return fail("unknown or expired transfer");
+	const pixels = transfer.data;
+	const offset = data.offset;
+	const length = data.length;
+	if (
+		pixels === undefined || !integer(offset, 0, pixels.size() - 1) ||
+		!integer(length, 1, CHUNK_BYTES) || offset !== transfer.offset ||
+		length !== math.min(CHUNK_BYTES, pixels.size() - offset)
+	) {
+		discard(id);
+		return fail("invalid chunk offset or length");
+	}
+	const chunk = pixels.sub(offset + 1, offset + length);
+	transfer.offset += length;
+	// Last read releases immediately, even if the receiver disappears before
+	// its explicit release. Explicit release is idempotent for error paths.
+	if (transfer.offset === pixels.size()) discard(id);
+	return { transferId: id, offset, data: chunk };
+}
+
+function receive(invoke: Invoke, data: Record<string, unknown>): unknown {
+	const id = HttpService.GenerateGUID(false);
+	const [ok, result] = pcall(() => {
+		// Older clients return inline data and may disconnect on a large capture.
+		// Probe a harmless release of our fresh ID before requesting any pixels.
+		const probe = invoke(RELEASE_ENDPOINT, { transferId: id });
+		if (!typeIs(probe, "table")) return { unavailable: "Client capture lacks bounded transfer support" };
+		const capability = probe as Record<string, unknown>;
+		if (capability.success !== true || capability.chunkBytes !== CHUNK_BYTES) {
+			return { unavailable: "Client capture lacks bounded transfer support" };
+		}
+		const response = invoke("/api/capture-studio", { encoding: data.encoding, transferId: id });
+		if (!typeIs(response, "table")) error("invalid transfer response");
+		const fields = response as Record<string, unknown>;
+		if (typeIs(fields.unavailable, "string")) return { unavailable: fields.unavailable.sub(1, 4096) };
+		if (typeIs(fields.error, "string")) error(fields.error.sub(1, 4096));
+		const info = metadata(fields.metadata);
+		if (info === undefined || fields.transferId !== id || fields.chunkBytes !== CHUNK_BYTES || !validSize(fields.totalBytes, info)) {
+			error("invalid transfer metadata or size");
+		}
+		const size = fields.totalBytes;
+		const chunks: string[] = [];
+		let offset = 0;
+		while (offset < size) {
+			const length = math.min(CHUNK_BYTES, size - offset);
+			const response = invoke(READ_ENDPOINT, { transferId: id, offset, length });
+			if (!typeIs(response, "table")) error("invalid chunk response");
+			const chunk = response as Record<string, unknown>;
+			if (typeIs(chunk.error, "string")) error(chunk.error.sub(1, 4096));
+			if (chunk.transferId !== id || chunk.offset !== offset || !typeIs(chunk.data, "string") || chunk.data.size() !== length) {
+				error("chunk ID, offset or length mismatch");
+			}
+			chunks.push(chunk.data);
+			offset += length;
+		}
+		return {
+			success: true, encoding: info.encoding, source: info.source,
+			width: info.width, height: info.height,
+			nativeWidth: info.nativeWidth, nativeHeight: info.nativeHeight,
+			data: chunks.join(""),
+		};
+	});
+	// The final read already frees successful transfers. Cleanup is best-effort:
+	// it must not mask an unavailable signal from an older client or a completed
+	// image. Failed partial transfers also have the bounded expiry above.
+	pcall(() => invoke(RELEASE_ENDPOINT, { transferId: id }));
+	if (!ok) return fail(tostring(result));
+	return result;
+}
+
+export = { READ_ENDPOINT, RELEASE_ENDPOINT, begin, read, release, receive };

--- a/studio-plugin/src/modules/ClientBroker.ts
+++ b/studio-plugin/src/modules/ClientBroker.ts
@@ -3,6 +3,7 @@ import RuntimeLogBuffer from "./RuntimeLogBuffer";
 import MemoryHandlers from "./handlers/MemoryHandlers";
 import SceneAnalysisHandlers from "./handlers/SceneAnalysisHandlers";
 import CaptureHandlers from "./handlers/CaptureHandlers";
+import CaptureTransfer from "./CaptureTransfer";
 import InputHandlers from "./handlers/InputHandlers";
 import MetadataHandlers from "./handlers/MetadataHandlers";
 import EvalRuntimeHandlers from "./handlers/EvalRuntimeHandlers";
@@ -238,7 +239,13 @@ function setupClientBroker(attempt = 0) {
 			return CaptureHandlers.captureBegin();
 		}
 		if (payload && payload.endpoint === "/api/capture-studio") {
-			return CaptureHandlers.captureStudio(payload.data ?? {});
+			return CaptureTransfer.begin(payload.data ?? {}, () => CaptureHandlers.captureStudio(payload.data ?? {}));
+		}
+		if (payload && payload.endpoint === CaptureTransfer.READ_ENDPOINT) {
+			return CaptureTransfer.read(payload.data ?? {});
+		}
+		if (payload && payload.endpoint === CaptureTransfer.RELEASE_ENDPOINT) {
+			return CaptureTransfer.release(payload.data ?? {});
 		}
 		if (payload && payload.endpoint === "/api/simulate-mouse-input") {
 			return InputHandlers.simulateMouseInput(payload.data ?? {});
@@ -518,6 +525,12 @@ function dispatchClientRequest(
 		return {
 			error: `Client-proxy does not forward ${endpoint}. Allowed: ${allowed.join(", ")}.`,
 		};
+	}
+	if (endpoint === "/api/capture-studio") {
+		return CaptureTransfer.receive(
+			(captureEndpoint, captureData) => entry.remote.InvokeClient(entry.player, { endpoint: captureEndpoint, data: captureData }),
+			data ?? {},
+		);
 	}
 
 	const envelope = { endpoint, data };

--- a/studio-plugin/src/modules/ClientBroker.ts
+++ b/studio-plugin/src/modules/ClientBroker.ts
@@ -72,9 +72,12 @@ const CLIENT_BROKER_ALLOWED_ENDPOINTS = new Set<string>([
 	"/api/capture-micro-profiler",
 	"/api/multiplayer-test-state",
 	"/api/multiplayer-test-leave-client",
-	// Screenshot capture must run in the client peer (CaptureService captures
-	// the play viewport there); the edit DM reads the temp id back separately.
+	// Screenshot capture must run in the client peer: CaptureService captures
+	// the play viewport there (the edit DM reads the temp id back separately),
+	// and StudioCaptureService only completes in the DataModel that is being
+	// rendered — during a playtest that is the client, never the edit peer.
 	"/api/capture-begin",
+	"/api/capture-studio",
 	// Virtual input (CreateVirtualInput) drives the running client's input
 	// pipeline, so it must execute in the client peer's VM.
 	"/api/simulate-mouse-input",
@@ -233,6 +236,9 @@ function setupClientBroker(attempt = 0) {
 		}
 		if (payload && payload.endpoint === "/api/capture-begin") {
 			return CaptureHandlers.captureBegin();
+		}
+		if (payload && payload.endpoint === "/api/capture-studio") {
+			return CaptureHandlers.captureStudio(payload.data ?? {});
 		}
 		if (payload && payload.endpoint === "/api/simulate-mouse-input") {
 			return InputHandlers.simulateMouseInput(payload.data ?? {});

--- a/studio-plugin/src/modules/Communication.ts
+++ b/studio-plugin/src/modules/Communication.ts
@@ -79,6 +79,7 @@ const routeMap: Record<string, Handler> = {
 	"/api/preview-asset": AssetHandlers.previewAsset,
 
 	"/api/capture-screenshot": CaptureHandlers.captureScreenshot,
+	"/api/capture-studio": CaptureHandlers.captureStudio,
 	"/api/capture-begin": CaptureHandlers.captureBegin,
 	"/api/capture-read": CaptureHandlers.captureRead,
 	"/api/simulate-mouse-input": InputHandlers.simulateMouseInput,

--- a/studio-plugin/src/modules/handlers/CaptureHandlers.ts
+++ b/studio-plugin/src/modules/handlers/CaptureHandlers.ts
@@ -2,12 +2,60 @@ import * as RenderMonitor from "../RenderMonitor";
 
 const CaptureService = game.GetService("CaptureService");
 const AssetService = game.GetService("AssetService");
+const Workspace = game.GetService("Workspace");
 
 const MAX_TILE_SIZE = 1024;
 const MAX_RAW_PIXEL_BYTES = 36 * 1024 * 1024;
 const MAX_CREATED_IMAGE_DIM = 2048;
 const BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 const PAD_BYTE = string.byte("=")[0];
+
+// StudioCaptureService (Studio-only, PluginSecurity) is the fast path: it hands
+// back the framebuffer directly, so it needs neither CaptureService's
+// asynchronous callback nor an EditableImage round-trip — and it captures at
+// ViewportSize, which is exactly the coordinate space simulate_mouse_input
+// expects. It is gated behind Studio FFlags and is missing from @rbxts/types,
+// hence the local structural declarations below.
+interface CaptureEnumItem {
+	readonly Name: string;
+}
+
+interface StudioScreenshotOptions {
+	CaptureSize: Vector2;
+	OutputSize?: Vector2;
+	ResampleMode?: Enum.ResamplerMode;
+	Position?: Vector2;
+	Format?: CaptureEnumItem;
+	UICaptureMode?: Enum.UICaptureMode;
+}
+
+interface StudioScreenshotCapture {
+	readonly BufferStatus: CaptureEnumItem;
+	readonly BufferFormat: CaptureEnumItem;
+	readonly OriginalSize: Vector2;
+	readonly Resolution: Vector2;
+	GetBuffer(this: StudioScreenshotCapture): buffer;
+	GetErrors(this: StudioScreenshotCapture): unknown[];
+}
+
+interface StudioCaptureServiceLike {
+	CanCaptureScreenshot(this: StudioCaptureServiceLike): boolean;
+	CaptureScreenshot(
+		this: StudioCaptureServiceLike,
+		options: StudioScreenshotOptions,
+	): StudioScreenshotCapture | undefined;
+}
+
+// Unchecked cast, single reason: these enums exist in Studio but are missing
+// from @rbxts/types, so the global Enum table has to be read dynamically.
+const ENUM_TABLE = Enum as unknown as Record<string, Record<string, CaptureEnumItem> | undefined>;
+const STUDIO_CAPTURE_FORMATS = ENUM_TABLE.StudioCaptureScreenshotFormat;
+
+// Measured on a 1980x1032 viewport: RGBA8 completes in ~0.16s and PNG in ~1s.
+// A capture that is still Pending well past that never completes (it happens
+// while a playtest owns the renderer), so we stop waiting and let the caller
+// fall back instead of stalling the tool call.
+const STUDIO_CAPTURE_TIMEOUT = 3;
 
 const B64: number[] = [];
 for (let i = 0; i < 64; i++) {
@@ -168,6 +216,102 @@ function readContentToBase64(contentId: string): unknown {
 	return { success: true, width: w, height: h, data: base64Data, nativeWidth: nativeW, nativeHeight: nativeH };
 }
 
+let cachedStudioService: StudioCaptureServiceLike | undefined;
+
+function getStudioCaptureService(): StudioCaptureServiceLike | undefined {
+	if (cachedStudioService !== undefined) return cachedStudioService;
+	// Unchecked cast, single reason: StudioCaptureService is absent from
+	// @rbxts/types, so GetService cannot be called through the typed overload.
+	const dynamicGame = game as unknown as { GetService(name: string): unknown };
+	const [ok, service] = pcall(() => dynamicGame.GetService("StudioCaptureService"));
+	if (!ok || service === undefined) return undefined;
+	cachedStudioService = service as StudioCaptureServiceLike;
+	return cachedStudioService;
+}
+
+// Captures through StudioCaptureService. Returns undefined when the service
+// cannot capture right now (missing FFlag, permission not granted, or this
+// DataModel is not the active one) so the caller can fall back to the
+// CaptureService + EditableImage path.
+function doStudioCapture(wantPng: boolean): unknown | undefined {
+	if (STUDIO_CAPTURE_FORMATS === undefined) return undefined;
+
+	const service = getStudioCaptureService();
+	if (service === undefined) return undefined;
+
+	const [canOk, can] = pcall(() => service.CanCaptureScreenshot());
+	if (!canOk || can !== true) return undefined;
+
+	const camera = Workspace.CurrentCamera;
+	if (camera === undefined) return undefined;
+
+	const viewport = camera.ViewportSize;
+	const nativeW = math.max(1, math.floor(viewport.X));
+	const nativeH = math.max(1, math.floor(viewport.Y));
+	const captureSize = new Vector2(nativeW, nativeH);
+
+	const options: StudioScreenshotOptions = {
+		CaptureSize: captureSize,
+		Format: wantPng ? STUDIO_CAPTURE_FORMATS.PNG : STUDIO_CAPTURE_FORMATS.RGBA8,
+	};
+
+	let w = nativeW;
+	let h = nativeH;
+
+	// Raw RGBA rides back base64-encoded, so an oversized viewport is
+	// downscaled by the engine during the capture itself — no second pass.
+	if (!wantPng && nativeW * nativeH * 4 > MAX_RAW_PIXEL_BYTES) {
+		const scale = math.sqrt(MAX_RAW_PIXEL_BYTES / (nativeW * nativeH * 4));
+		w = math.max(1, math.floor(nativeW * scale));
+		h = math.max(1, math.floor(nativeH * scale));
+		options.OutputSize = new Vector2(w, h);
+		options.ResampleMode = Enum.ResamplerMode.Default;
+	}
+
+	const [captureOk, captureResult] = pcall(() => service.CaptureScreenshot(options));
+	if (!captureOk) return { error: `StudioCaptureService:CaptureScreenshot failed: ${tostring(captureResult)}` };
+	if (captureResult === undefined) return undefined;
+
+	const capture = captureResult;
+	const startTime = tick();
+	while (capture.BufferStatus.Name === "Pending" || capture.BufferStatus.Name === "NotStarted") {
+		if (tick() - startTime > STUDIO_CAPTURE_TIMEOUT) return undefined;
+		task.wait(0.02);
+	}
+
+	if (capture.BufferStatus.Name !== "Ready") {
+		const [errorsOk, errors] = pcall(() => capture.GetErrors());
+		const detail = errorsOk ? game.GetService("HttpService").JSONEncode(errors) : "unavailable";
+		return { error: `StudioCaptureService capture failed (status ${capture.BufferStatus.Name}): ${detail}` };
+	}
+
+	const [bufferOk, captureBuffer] = pcall(() => capture.GetBuffer());
+	if (!bufferOk) return { error: `StudioCaptureService:GetBuffer failed: ${tostring(captureBuffer)}` };
+
+	const resolution = capture.Resolution;
+	return {
+		success: true,
+		encoding: wantPng ? "png" : "rgba8",
+		source: "StudioCaptureService",
+		width: math.max(1, math.floor(resolution.X)),
+		height: math.max(1, math.floor(resolution.Y)),
+		nativeWidth: nativeW,
+		nativeHeight: nativeH,
+		data: encodeBase64(captureBuffer as buffer),
+	};
+}
+
+// Studio-only capture endpoint. Reports `unavailable` (instead of an error) so
+// the server can fall back to the legacy CaptureService path.
+function captureStudio(requestData: Record<string, unknown>): unknown {
+	const wantPng = requestData.encoding === "png";
+	const result = doStudioCapture(wantPng);
+	if (result === undefined) {
+		return { unavailable: "StudioCaptureService cannot capture this DataModel right now" };
+	}
+	return result;
+}
+
 // Edit-mode single shot: capture and read back in the same (edit) context.
 function captureScreenshotData(): unknown {
 	const cap = doCaptureScreenshot();
@@ -194,6 +338,7 @@ function captureRead(requestData: Record<string, unknown>): unknown {
 export = {
 	captureScreenshotData,
 	captureScreenshot,
+	captureStudio,
 	captureBegin,
 	captureRead,
 };

--- a/studio-plugin/src/modules/handlers/CaptureHandlers.ts
+++ b/studio-plugin/src/modules/handlers/CaptureHandlers.ts
@@ -21,9 +21,8 @@ interface CaptureEnumItem {
 }
 
 interface StudioScreenshotOptions {
-	CaptureSize: Vector2;
-	OutputSize?: Vector2;
-	ResampleMode?: Enum.ResamplerMode;
+	OutputSize: Vector2;
+	ResampleMode: Enum.ResamplerMode;
 	Position?: Vector2;
 	Format?: CaptureEnumItem;
 	UICaptureMode?: Enum.UICaptureMode;
@@ -248,13 +247,6 @@ function doStudioCapture(wantPng: boolean): unknown | undefined {
 	const viewport = camera.ViewportSize;
 	const nativeW = math.max(1, math.floor(viewport.X));
 	const nativeH = math.max(1, math.floor(viewport.Y));
-	const captureSize = new Vector2(nativeW, nativeH);
-
-	const options: StudioScreenshotOptions = {
-		CaptureSize: captureSize,
-		Format: wantPng ? STUDIO_CAPTURE_FORMATS.PNG : STUDIO_CAPTURE_FORMATS.RGBA8,
-	};
-
 	let w = nativeW;
 	let h = nativeH;
 
@@ -264,9 +256,15 @@ function doStudioCapture(wantPng: boolean): unknown | undefined {
 		const scale = math.sqrt(MAX_RAW_PIXEL_BYTES / (nativeW * nativeH * 4));
 		w = math.max(1, math.floor(nativeW * scale));
 		h = math.max(1, math.floor(nativeH * scale));
-		options.OutputSize = new Vector2(w, h);
-		options.ResampleMode = Enum.ResamplerMode.Default;
 	}
+
+	// CaptureSize is a framebuffer crop, not the logical viewport size. At
+	// fractional display scaling it cuts off the right/bottom of the frame.
+	const options: StudioScreenshotOptions = {
+		OutputSize: new Vector2(w, h),
+		ResampleMode: Enum.ResamplerMode.Default,
+		Format: wantPng ? STUDIO_CAPTURE_FORMATS.PNG : STUDIO_CAPTURE_FORMATS.RGBA8,
+	};
 
 	const [captureOk, captureResult] = pcall(() => service.CaptureScreenshot(options));
 	if (!captureOk) return { error: `StudioCaptureService:CaptureScreenshot failed: ${tostring(captureResult)}` };

--- a/tests/capture-broker-transfers.mjs
+++ b/tests/capture-broker-transfers.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// Run after building the plugin, through run-all.mjs --managed --test capture-broker-transfers.mjs.
+// Executes the real compiled transport in Studio with a fake clock and in-memory
+// InvokeClient adapter. Full engine/framebuffer coverage lives in capture-regressions.mjs.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { McpClient, runTest } from './lib/mcp-client.mjs';
+
+const transport = readFileSync(new URL('../studio-plugin/out/modules/CaptureTransfer.luau', import.meta.url), 'utf8');
+
+await runTest('Capture broker bounded chunk transport', async ({ track }) => {
+  const client = track(new McpClient('capture-broker-transfers', { startupTimeoutMs: 20000 }));
+  await client.start();
+  await client.initialize();
+  const instanceId = process.env.MCP_INSTANCE_ID;
+  assert.ok(instanceId, 'Run with an explicitly targeted managed instance');
+  const result = await client.callTool('execute_luau', {
+    instance_id: instanceId,
+    target: 'edit',
+    code: `
+local now = 0
+local timers = {}
+local os = {clock = function() return now end}
+local task = {
+  delay = function(seconds, callback)
+    local timer = {at = now + seconds, callback = callback}
+    table.insert(timers, timer)
+    return timer
+  end,
+  cancel = function(timer) timer.cancelled = true end,
+}
+local transfer = (function()
+${transport}
+end)()
+local chunkSize = 1024 * 1024
+local pixelsA = string.rep('A', chunkSize) .. 'AAAA'
+local pixelsB = string.rep('B', chunkSize) .. 'BBBB'
+local function capture(pixels)
+  return {success = true, encoding = 'png', source = 'StudioCaptureService', width = 1024, height = 1024,
+    nativeWidth = 1024, nativeHeight = 1024, data = pixels}
+end
+local function begin(id, pixels)
+  return transfer.begin({transferId = id}, function() return capture(pixels) end)
+end
+local function read(id, offset, length)
+  return transfer.read({transferId = id, offset = offset, length = length})
+end
+local function release(id) return transfer.release({transferId = id}) end
+
+-- Admission is bounded, duplicate IDs never overwrite another capture, and
+-- independently interleaved chunks retain the correct bytes and offsets.
+local a = begin('a', pixelsA)
+local b = begin('b', pixelsB)
+assert(a.data == nil and b.data == nil and a.totalBytes == #pixelsA)
+assert(begin('a', pixelsB).error, 'duplicate transfer must not overwrite')
+assert(begin('c', pixelsA).error, 'third capture must fail without evicting')
+assert(read('b', 0, chunkSize).data == string.sub(pixelsB, 1, chunkSize))
+assert(read('a', 0, chunkSize).data == string.sub(pixelsA, 1, chunkSize))
+assert(read('a', chunkSize, 4).data == 'AAAA')
+assert(begin('c', pixelsA).transferId == 'c', 'last chunk must release capacity')
+assert(read('b', chunkSize, 4).data == 'BBBB')
+assert(read('a', 0, chunkSize).error, 'completed transfer cannot be read again')
+release('c')
+
+-- Capture itself yields in Studio. Capacity must already be reserved while
+-- that callback is running, not just when it finally returns its bytes.
+local reserved = transfer.begin({transferId = 'capturing'}, function()
+  assert(begin('second', pixelsB).transferId == 'second')
+  assert(begin('third', pixelsA).error, 'in-progress capture must count toward the limit')
+  release('second')
+  return capture(pixelsA)
+end)
+assert(reserved.transferId == 'capturing')
+release('capturing')
+assert(transfer.begin({transferId = 'throws'}, function() error('capture failure') end).error)
+assert(begin('throws', pixelsA).transferId == 'throws', 'capture failure must release its reservation')
+release('throws')
+
+-- Invalid reads release only their transfer; offset/length cannot truncate,
+-- repeat, skip, or exceed the declared chunk limit.
+for _, request in ipairs({
+  {offset = -1, length = chunkSize}, {offset = 0.5, length = chunkSize},
+  {offset = 1, length = chunkSize}, {offset = 0, length = chunkSize + 1},
+  {offset = 0, length = 1}, {offset = 0, length = 0},
+}) do
+  assert(begin('bad', pixelsA).transferId == 'bad')
+  request.transferId = 'bad'
+  assert(transfer.read(request).error)
+  assert(read('bad', 0, chunkSize).error, 'invalid read must discard retained data')
+end
+assert(begin('keep', pixelsB).transferId == 'keep')
+assert(read('missing', 0, chunkSize).error)
+assert(read('keep', 0, chunkSize).data == string.sub(pixelsB, 1, chunkSize))
+release('keep')
+for _, timer in ipairs(timers) do assert(timer.cancelled, 'settled transfers must cancel expiry tasks') end
+
+-- Expiry is deterministic and runs without another incoming request.
+assert(begin('expired', pixelsA).transferId == 'expired')
+now = 61
+for _, timer in ipairs(timers) do if not timer.cancelled and timer.at <= now then timer.callback() end end
+assert(read('expired', 0, chunkSize).error)
+assert(begin('fresh', pixelsB).transferId == 'fresh')
+release('fresh')
+
+-- Server reassembly crosses the same seam used by ClientBroker. It must reject
+-- wrong IDs, offsets, lengths and metadata, and release even when invoke throws.
+local function roundTrip(mode)
+  local released = false
+  local invokedId
+  local function invoke(endpoint, data)
+    if endpoint == transfer.RELEASE_ENDPOINT then
+      released = true
+      if mode == 'release-failure' and invokedId ~= nil then return {error = 'cleanup unavailable'} end
+      return release(data.transferId)
+    end
+    if endpoint == '/api/capture-studio' then
+      invokedId = data.transferId
+      if mode == 'unavailable' then return {unavailable = 'beta disabled'} end
+      local header = begin(data.transferId, pixelsA)
+      if mode == 'size' then header.totalBytes = 64 * 1024 * 1024 + 4 end
+      return header
+    end
+    assert(endpoint == transfer.READ_ENDPOINT)
+    assert(data.length <= chunkSize, 'wire chunk exceeds limit')
+    if mode == 'throw' then error('simulated remote failure') end
+    local chunk = transfer.read(data)
+    if mode == 'id' then chunk.transferId = 'another transfer' end
+    if mode == 'offset' then chunk.offset += 1 end
+    if mode == 'length' then chunk.data = string.sub(chunk.data, 2) end
+    return chunk
+  end
+  local response = transfer.receive(invoke, {encoding = 'png'})
+  assert(released, 'release must run on every outcome')
+  assert(read(invokedId, 0, chunkSize).error, 'receiver must leave no retained transfer')
+  return response
+end
+local full = roundTrip('ok')
+assert(full.success and full.data == pixelsA and full.encoding == 'png' and full.width == 1024)
+assert(full.transferId == nil, 'internal protocol must not leak into public result')
+for _, mode in ipairs({'size', 'throw', 'id', 'offset', 'length'}) do
+  local response = roundTrip(mode)
+  assert(response.success == false and type(response.error) == 'string', mode .. ' must fail clearly')
+end
+assert(roundTrip('unavailable').unavailable == 'beta disabled', 'legacy fallback signal must survive')
+assert(roundTrip('release-failure').data == pixelsA, 'cleanup must not mask a complete result')
+local oldCaptureRequests = 0
+local old = transfer.receive(function(endpoint)
+  if endpoint == '/api/capture-studio' then
+    oldCaptureRequests += 1
+    return {unavailable = 'beta disabled'}
+  end
+  return {error = 'Unsupported client broker endpoint: ' .. endpoint}
+end, {encoding = 'png'})
+assert(old.unavailable, 'older clients must retain legacy fallback')
+assert(oldCaptureRequests == 0, 'negotiate bounded transfer before requesting potentially oversized inline data')
+local oldServer = transfer.begin({encoding = 'png'}, function()
+  error('an older server must not trigger an unbounded capture')
+end)
+assert(oldServer.unavailable, 'older servers must retain legacy fallback')
+assert(transfer.begin({transferId = 42}, function() return capture(pixelsA) end).error, 'malformed supplied IDs must fail')
+local rejected = transfer.begin({transferId = 'bad-size'}, function()
+  return {success = true, encoding = 'rgba8', source = 'StudioCaptureService', width = 2, height = 2,
+    nativeWidth = 2, nativeHeight = 2, data = 'AAAA'}
+end)
+assert(rejected.error, 'RGBA dimensions must agree with encoded byte size')
+assert(begin('after-error', pixelsA).transferId == 'after-error')
+release('after-error')
+return 'capture-transfer-regressions-passed'
+`,
+  });
+  assert.equal(result.success, true, JSON.stringify(result));
+  assert.equal(String(result.returnValue), 'capture-transfer-regressions-passed');
+});

--- a/tests/capture-regressions.mjs
+++ b/tests/capture-regressions.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+// Run through run-all.mjs --managed --test capture-regressions.mjs.
+// Set RSMCP_EXPECT_STUDIO_CAPTURE=enabled or disabled after configuring Studio's flag.
+// Requires an idle instance with device simulation off; restores both on completion.
+import assert from 'node:assert/strict';
+import { inflateSync } from 'node:zlib';
+import { McpClient, runTest } from './lib/mcp-client.mjs';
+
+// Decode the engine/host's 8-bit RGB(A) PNGs so assertions inspect actual pixels,
+// not just metadata (a correctly sized crop was the original regression).
+function decodePng(data) {
+  assert.equal(data.subarray(0, 8).toString('hex'), '89504e470d0a1a0a');
+  let width, height, channels;
+  const chunks = [];
+  for (let offset = 8; offset < data.length;) {
+    const length = data.readUInt32BE(offset);
+    const kind = data.toString('ascii', offset + 4, offset + 8);
+    const body = data.subarray(offset + 8, offset + 8 + length);
+    if (kind === 'IHDR') {
+      width = body.readUInt32BE(0); height = body.readUInt32BE(4);
+      assert.equal(body[8], 8, '8-bit PNG');
+      assert.ok(body[9] === 2 || body[9] === 6, 'RGB or RGBA PNG');
+      assert.equal(body[12], 0, 'non-interlaced PNG');
+      channels = body[9] === 6 ? 4 : 3;
+    }
+    if (kind === 'IDAT') chunks.push(body);
+    offset += length + 12;
+  }
+  assert.ok(width && height && channels);
+  const stride = width * channels;
+  const filtered = inflateSync(Buffer.concat(chunks));
+  assert.equal(filtered.length, (stride + 1) * height);
+  const pixels = Buffer.alloc(stride * height);
+  for (let y = 0; y < height; y++) {
+    const filter = filtered[y * (stride + 1)];
+    assert.ok(filter <= 4);
+    for (let x = 0; x < stride; x++) {
+      const index = y * stride + x;
+      const left = x >= channels ? pixels[index - channels] : 0;
+      const up = y > 0 ? pixels[index - stride] : 0;
+      const upperLeft = y > 0 && x >= channels ? pixels[index - stride - channels] : 0;
+      let predictor = 0;
+      if (filter === 1) predictor = left;
+      if (filter === 2) predictor = up;
+      if (filter === 3) predictor = Math.floor((left + up) / 2);
+      if (filter === 4) {
+        const p = left + up - upperLeft;
+        const a = Math.abs(p - left), b = Math.abs(p - up), c = Math.abs(p - upperLeft);
+        predictor = a <= b && a <= c ? left : b <= c ? up : upperLeft;
+      }
+      pixels[index] = (filtered[y * (stride + 1) + 1 + x] + predictor) & 255;
+    }
+  }
+  return { width, height, channels, pixels };
+}
+
+function colorBounds(image, red, green, blue) {
+  let minX = image.width, minY = image.height, maxX = -1, maxY = -1;
+  for (let y = 0; y < image.height; y++) for (let x = 0; x < image.width; x++) {
+    const i = (y * image.width + x) * image.channels;
+    if (Math.abs(image.pixels[i] - red) < 16 && Math.abs(image.pixels[i + 1] - green) < 16 && Math.abs(image.pixels[i + 2] - blue) < 16) {
+      minX = Math.min(minX, x); minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x); maxY = Math.max(maxY, y);
+    }
+  }
+  assert.ok(maxX >= minX && maxY >= minY, `Missing RGB(${red},${green},${blue}) marker`);
+  return [minX, minY, maxX, maxY];
+}
+
+await runTest('Screenshot beta and legacy regressions', async ({ track }) => {
+  const expectation = process.env.RSMCP_EXPECT_STUDIO_CAPTURE;
+  assert.ok(['enabled', 'disabled'].includes(expectation), 'Set RSMCP_EXPECT_STUDIO_CAPTURE explicitly');
+  const enabled = expectation === 'enabled';
+  const instanceId = process.env.MCP_INSTANCE_ID;
+  assert.ok(instanceId, 'Run with an explicitly targeted managed instance');
+  const client = track(new McpClient('capture-regressions', { startupTimeoutMs: 20000 }));
+  await client.start(); await client.initialize();
+  const tool = (name, args = {}) => client.callTool(name, { instance_id: instanceId, ...args }, 120000);
+  async function execute(code, target = 'edit') {
+    const result = await tool('execute_luau', { target, code });
+    assert.equal(result.success, true, JSON.stringify(result));
+    return JSON.parse(result.returnValue);
+  }
+  async function capture(format, quality = 80) {
+    const result = await client.rpc('tools/call', {
+      name: 'capture_screenshot', arguments: { instance_id: instanceId, format, quality },
+    }, 120000);
+    assert.notEqual(result.isError, true, JSON.stringify(result));
+    const image = result.content?.find(item => item.type === 'image');
+    assert.ok(image, JSON.stringify(result));
+    assert.equal(image.mimeType, format === 'png' ? 'image/png' : 'image/jpeg');
+    const bytes = Buffer.from(image.data, 'base64');
+    if (format === 'jpeg') {
+      assert.equal(bytes.subarray(0, 2).toString('hex'), 'ffd8');
+      assert.equal(bytes.subarray(-2).toString('hex'), 'ffd9');
+    } else decodePng(bytes);
+    return bytes;
+  }
+  const topology = await tool('get_connected_instances');
+  const instance = topology.instances.find(item => item.id === instanceId);
+  assert.ok(instance?.peers.edit);
+  assert.ok(!instance.peers.server && !instance.peers['client-1'], 'Start with an idle Studio');
+  const simulator = await tool('get_device_simulator_state', { target: 'edit' });
+  assert.equal(simulator.isSimulating, false, 'Start with device simulation off');
+  const capability = await execute("return {can=game:GetService('StudioCaptureService'):CanCaptureScreenshot()}");
+  assert.equal(capability.can, enabled, 'Studio must be restarted with the expected beta flag');
+  const endpoint = await execute("local r=require(script.modules.handlers.CaptureHandlers).captureStudio({encoding='png'});return {source=r.source,unavailable=r.unavailable,error=r.error}");
+  if (enabled) assert.equal(endpoint.source, 'StudioCaptureService');
+  else assert.ok(endpoint.unavailable, JSON.stringify(endpoint));
+  let playing = false;
+  try {
+    await capture('png');
+    const low = await capture('jpeg', 20), high = await capture('jpeg', 90);
+    assert.ok(!low.equals(high), 'JPEG quality changes output');
+    console.log(`Edit PNG/JPEG and quality passed (beta ${expectation}, proxy=${client.isProxy()})`);
+    // A stable density override creates a logical/framebuffer size mismatch on
+    // desktop monitors without changing Windows display settings.
+    await tool('set_device_simulator', { target: 'edit', deviceId: 'hd_1080', resolution: { width: 1600, height: 900 }, pixelDensity: 88 });
+    playing = true;
+    assert.equal((await tool('solo_playtest', { action: 'start', mode: 'play' })).success, true);
+    await execute(`
+local pg=game:GetService('Players').LocalPlayer:WaitForChild('PlayerGui')
+local gui=Instance.new('ScreenGui');gui.Name='__RSMCP_CaptureRegression';gui.IgnoreGuiInset=true;gui.DisplayOrder=10000;gui.ResetOnSpawn=false;gui.Parent=pg
+local b=Instance.new('TextButton');b.Position=UDim2.fromOffset(600,350);b.Size=UDim2.fromOffset(120,80);b.Text='';b.AutoButtonColor=false;b.BorderSizePixel=0;b.BackgroundColor3=Color3.fromRGB(255,0,255);b.Parent=gui
+local edge=Instance.new('Frame');edge.Position=UDim2.fromOffset(1300,700);edge.Size=UDim2.fromOffset(120,80);edge.BorderSizePixel=0;edge.BackgroundColor3=Color3.fromRGB(0,255,255);edge.Parent=gui
+ gui:SetAttribute('Clicks',0);b.MouseButton1Click:Connect(function()gui:SetAttribute('Clicks',gui:GetAttribute('Clicks')+1)end)
+game:GetService('RunService').RenderStepped:Wait();game:GetService('RunService').RenderStepped:Wait();return true`, 'client-1');
+    const image = decodePng(await capture('png'));
+    const magenta = colorBounds(image, 255, 0, 255);
+    const cyan = colorBounds(image, 0, 255, 255);
+    if (enabled) {
+      assert.equal(image.width, 1600); assert.equal(image.height, 900);
+      for (const [actual, expected] of [[magenta[0], 600], [magenta[1], 350], [cyan[0], 1300], [cyan[1], 700]]) {
+        assert.ok(Math.abs(actual - expected) <= 1, `Expected logical pixel ${expected}; got ${actual}`);
+      }
+      await tool('simulate_mouse_input', { target: 'client-1', action: 'click', x: Math.round((magenta[0] + magenta[2]) / 2), y: Math.round((magenta[1] + magenta[3]) / 2) });
+      const clicks = await execute("return game:GetService('Players').LocalPlayer.PlayerGui.__RSMCP_CaptureRegression:GetAttribute('Clicks')", 'client-1');
+      assert.equal(clicks, 1, 'Screenshot coordinates click the real GUI target');
+    }
+    await capture('jpeg');
+    console.log(`Scaled play PNG/JPEG passed: ${image.width}x${image.height}; markers ${magenta}, ${cyan}`);
+    await tool('set_device_simulator', { target: 'client-1', resolution: { width: 3840, height: 2160 }, pixelDensity: 96 });
+    await execute("game:GetService('RunService').RenderStepped:Wait();game:GetService('RunService').RenderStepped:Wait();return true", 'client-1');
+    await capture('jpeg', 70);
+    await capture('jpeg', 90);
+    if (enabled) {
+      // Two 4K base64 responses exceed the separate 64 MiB WebSocket
+      // retained-result budget. Exercise concurrent chunks within that bound.
+      await tool('set_device_simulator', { target: 'client-1', resolution: { width: 2560, height: 1440 } });
+      await execute("game:GetService('RunService').RenderStepped:Wait();game:GetService('RunService').RenderStepped:Wait();return true", 'client-1');
+      const concurrent = await Promise.allSettled([capture('jpeg', 70), capture('jpeg', 90)]);
+      for (const result of concurrent) {
+        assert.equal(result.status, 'fulfilled', result.status === 'rejected' ? String(result.reason) : undefined);
+      }
+    }
+    const stillAlive = await execute("return game:GetService('Players').LocalPlayer.Parent == game:GetService('Players')", 'client-1');
+    assert.equal(stillAlive, true, 'Large JPEG responses must not disconnect the client');
+    console.log(`4K play JPEGs${enabled ? ' and concurrent 1440p transfers' : ''} passed; client remains connected`);
+  } finally {
+    if (playing) await tool('solo_playtest', { action: 'stop' });
+    await tool('set_device_simulator', { target: 'edit', stopSimulation: true });
+  }
+  await capture('png');
+  console.log('Post-play edit capture passed');
+});

--- a/tests/run-all.mjs
+++ b/tests/run-all.mjs
@@ -34,6 +34,7 @@ const FULL_TESTS = [
   'path-resolution.mjs',
   'property-value-conversion.mjs',
   'luau-payload-transfers.mjs',
+  'capture-broker-transfers.mjs',
   'large-input-workflow.mjs',
   'studio-tooling-smoke.mjs',
   'eval-bridge-error-preservation.mjs',
@@ -59,13 +60,15 @@ const FEATURE_TESTS = [
 ];
 // Long-running/inherently failing investigation scenarios are explicit opt-ins.
 const DIAGNOSTIC_TESTS = ['luau-recipe-stress.mjs', 'luau-http-budget-repro.mjs', 'studio-websocket-quota.mjs'];
+// These require explicit environment setup and are not part of the default suite.
+const CONFIGURED_TESTS = ['capture-regressions.mjs'];
 const featureSmoke = process.argv.includes('--smoke');
 const requestedTestIndex = process.argv.indexOf('--test');
 const requestedTest = requestedTestIndex === -1 ? undefined : process.argv[requestedTestIndex + 1];
 if (requestedTestIndex !== -1 && !requestedTest) {
   throw new Error('--test requires a test filename');
 }
-if (requestedTest && !FULL_TESTS.includes(requestedTest) && !DIAGNOSTIC_TESTS.includes(requestedTest)) {
+if (requestedTest && !FULL_TESTS.includes(requestedTest) && !DIAGNOSTIC_TESTS.includes(requestedTest) && !CONFIGURED_TESTS.includes(requestedTest)) {
   throw new Error(`Unknown Studio test ${JSON.stringify(requestedTest)}`);
 }
 const TESTS = requestedTest ? [requestedTest] : (featureSmoke ? FEATURE_TESTS : FULL_TESTS);


### PR DESCRIPTION
## Problem

`capture_screenshot` triggers `CaptureService:CaptureScreenshot`, then promotes the resulting `rbxtemp://` texture into an `EditableImage` to read its pixels. That path:

- is slow — 1.4s inside the engine, 2.5-3.6s end to end;
- requires the *Allow Mesh / Image APIs* place setting;
- needs a client-to-edit handoff during a playtest (`/api/capture-begin` + `/api/capture-read`);
- silently drops the `SurfaceGui.AlwaysOnTop` layer, so overlay UI never appears in the screenshot;
- returns the DPI-scaled framebuffer (2476x1290 on a 1.25x display) while `simulate_mouse_input` coordinates are viewport points (1980x1032), so coordinates read off a screenshot are off by the display scale.

## Change

`StudioCaptureService` (Studio-only, `PluginSecurity`) returns the framebuffer directly. New plugin endpoint `/api/capture-studio` uses it and reports `unavailable` whenever it cannot, so the old path stays as the fallback.

- `CaptureSize` is the peer's `ViewportSize`, so the image is in the unit `simulate_mouse_input` expects.
- `format: "png"` asks the engine for `StudioCaptureScreenshotFormat.PNG` and the bytes pass through untouched; `jpeg` asks for `RGBA8` and the existing encoder applies `quality`.
- An oversized viewport is downscaled during the capture itself (`OutputSize` + `ResampleMode`), no `EditableImage` pass.
- The request follows the rendering peer: the edit peer while idle, the play client peer during a playtest (`ClientBroker`).

Fallback to the previous path when: the FFlag is off, `CanCaptureScreenshot()` is false, the capture stalls past 3s, or the installed plugin predates the endpoint.

## Measurements

Studio 0.738 with the service enabled, 1980x1032 viewport, RTX-class desktop.

| | new | old |
| --- | --- | --- |
| edit, in-engine | 0.16s (0.044s without `CaptureSize`) | 1.42s |
| edit, end to end (jpeg q80) | 0.88s | 2.56-3.63s |
| playtest, end to end (jpeg q80) | 1.26s | 1.76-2.71s |
| playtest, end to end (png) | 0.66s | n/a |
| `SurfaceGui.AlwaysOnTop` red panel | 21.8% of sampled pixels | 0% |
| image size | 1980x1067 (viewport points) | 2476x1290 (framebuffer) |

## Peer routing, verified live

With a playtest active, the edit peer still returns `CanCaptureScreenshot() == true`, but the capture never leaves `BufferStatus.Pending` — no errors, `Resolution 0, 0`, still pending 6s after the playtest stops, and unchanged with the Studio window focused. The same call inside the play client peer completes. Hence the routing by rendering peer rather than always using the edit peer.

`game:GetService("StudioCaptureService")` is `nil` in the play DataModel's *game* VM (no plugin security); it resolves in the client peer's plugin VM, which is where the endpoint runs.

## Availability

`StudioCaptureService` ships in Studio 0.738 but is gated. On a stock install `CanCaptureScreenshot()` returns `false` and `RequestScreenshotPermissionAsync()` raises `Feature not supported yet.`, so those installs keep the current behaviour with no change in output.

One flag turns it on:

```json
{ "FFlagImageScreenCaptureEnabled4": "True" }
```

in `%LOCALAPPDATA%\Roblox\ClientSettings\StudioAppSettings.json` (Studio restart required). Verified on stock Studio `version-93202a13414c4131`: with that single override, `CanCaptureScreenshot()` → `true` and a 1980x1067 capture reaches `BufferStatus.Ready` with an 8450640-byte RGBA8 buffer (= 1980 x 1067 x 4). `DFIntStudioPluginImageCapture=100` also works but is not required; `FFlagStudioPluginWindowScreenshot` gates `CapturePluginGui`, which this change does not use.

## Tests

`packages/core` suite passes (620 tests). Five `capture_screenshot` cases cover the fast path, the PNG pass-through, the play-client routing, the `unavailable` fallback and the old-plugin fallback.
